### PR TITLE
fix: address latent bugs flagged by Copilot review on PR #101

### DIFF
--- a/src/Officials/OfficialProfileSearchResults.tsx
+++ b/src/Officials/OfficialProfileSearchResults.tsx
@@ -68,8 +68,8 @@ function OfficialProfileSearchResults({
             <LoadingButton
               isLoading={isInviting}
               className="button is-small is-primary"
-              onClick={() => onInvite(profile.id)}
-              disabled={isInviting}
+              onClick={() => profile.id && onInvite(profile.id)}
+              disabled={isInviting || !profile.id}
             >
               <Trans>invite</Trans>
             </LoadingButton>

--- a/src/Pages/TeamRosterInvites.tsx
+++ b/src/Pages/TeamRosterInvites.tsx
@@ -55,11 +55,13 @@ function TeamRosterInvites({ match }: TeamRosterInvitesProps) {
       setInvite(
         mapApiRegistrationInviteToRegistrationInviteEntity(invite.data)
       );
-      setTournament(
-        mapApiTournamentToTournamentEntity(
-          invite.data.registration.tournament || DEFAULT_TOURNAMENT
-        )
-      );
+      if (invite.data.registration.tournament) {
+        setTournament(
+          mapApiTournamentToTournamentEntity(
+            invite.data.registration.tournament
+          )
+        );
+      }
       setRegistration(
         mapApiRegistrationToRegistrationEntity(invite.data.registration)
       );

--- a/src/Pages/TeamRosterInvites.tsx
+++ b/src/Pages/TeamRosterInvites.tsx
@@ -61,6 +61,8 @@ function TeamRosterInvites({ match }: TeamRosterInvitesProps) {
             invite.data.registration.tournament
           )
         );
+      } else {
+        setTournament(DEFAULT_TOURNAMENT);
       }
       setRegistration(
         mapApiRegistrationToRegistrationEntity(invite.data.registration)

--- a/src/PlayerStatsLog/View.tsx
+++ b/src/PlayerStatsLog/View.tsx
@@ -36,9 +36,13 @@ function PlayerStatsLogRow({
   return (
     <tr>
       <td className="player">
-        <Link to={`${playerViewBasePath}${playerStatLog.playerId}`}>
-          {playerName}
-        </Link>
+        {playerStatLog.playerId ? (
+          <Link to={`${playerViewBasePath}${playerStatLog.playerId}`}>
+            {playerName}
+          </Link>
+        ) : (
+          playerName
+        )}
       </td>
 
       <td className="player-span"></td>

--- a/src/Registrations/RegistrationResponseFieldDisplay.tsx
+++ b/src/Registrations/RegistrationResponseFieldDisplay.tsx
@@ -4,7 +4,7 @@ import { ApiCustomFieldType } from '../Shared/httpClient/apiTypes';
 import { Trans } from 'react-i18next';
 
 interface FieldProps {
-  value: string;
+  value: string | boolean;
 }
 
 function Date({ value }: FieldProps) {
@@ -59,12 +59,17 @@ function RegistrationResponseFieldDisplay({
   registrationResponse: RegistrationResponseEntity;
 }) {
   if (customField.type in FIELD) {
-    if (!registrationResponse.response[customField.id]) {
+    const response = registrationResponse.response as Record<
+      string,
+      string | boolean
+    >;
+    const value = response[customField.id];
+
+    if (value === undefined) {
       return <></>;
     }
 
     const Field = FIELD[customField.type];
-    const value = registrationResponse.response[customField.id];
     return <Field value={value} />;
   }
 

--- a/src/Registrations/RegistrationResponseFieldDisplay.tsx
+++ b/src/Registrations/RegistrationResponseFieldDisplay.tsx
@@ -65,7 +65,7 @@ function RegistrationResponseFieldDisplay({
     >;
     const value = response[customField.id];
 
-    if (value === undefined) {
+    if (value === undefined || value === '') {
       return <></>;
     }
 

--- a/src/Registrations/RegistrationResponseView.tsx
+++ b/src/Registrations/RegistrationResponseView.tsx
@@ -10,12 +10,21 @@ function RegistrationResponseView({
   registrationResponse,
   registration
 }: RegistrationResponseViewProps): React.ReactElement {
+  const response = registrationResponse.response as Record<
+    string,
+    string | boolean
+  >;
+
   return (
     <>
       {registration.customFields.map(customField => (
         <div key={customField.id} className="column is-12">
           <label className="label">{customField.label}</label>
-          <div>{registrationResponse.response[customField.id] || ''}</div>
+          <div>
+            {response[customField.id] !== undefined
+              ? String(response[customField.id])
+              : ''}
+          </div>
         </div>
       ))}
     </>

--- a/src/Registrations/dataMappers.test.ts
+++ b/src/Registrations/dataMappers.test.ts
@@ -1,0 +1,29 @@
+import { ApiRegistrationCustomField } from '../Shared/httpClient/apiTypes';
+import { mapApiCustomFieldToCustomFieldEntity } from './dataMappers';
+
+describe('mapApiCustomFieldToCustomFieldEntity', () => {
+  it('uses the API id when present', () => {
+    const apiCustomField: ApiRegistrationCustomField = {
+      id: 'some-id',
+      label: 'Shirt size',
+      type: 'text',
+      required: false
+    };
+
+    expect(mapApiCustomFieldToCustomFieldEntity(apiCustomField).id).toEqual(
+      'some-id'
+    );
+  });
+
+  it('falls back to the label when the API omits id, instead of colliding on an empty string', () => {
+    const apiCustomField: ApiRegistrationCustomField = {
+      label: 'Shirt size',
+      type: 'text',
+      required: false
+    };
+
+    expect(mapApiCustomFieldToCustomFieldEntity(apiCustomField).id).toEqual(
+      'Shirt size'
+    );
+  });
+});

--- a/src/Registrations/dataMappers.ts
+++ b/src/Registrations/dataMappers.ts
@@ -56,7 +56,7 @@ export const mapApiCustomFieldToCustomFieldEntity = (
   apiCustomField: ApiRegistrationCustomField
 ): CustomFieldEntity => {
   return {
-    id: apiCustomField.id,
+    id: apiCustomField.id ? apiCustomField.id : apiCustomField.label,
     label: apiCustomField.label,
     description: apiCustomField.description ? apiCustomField.description : '',
     type: apiCustomField.type,

--- a/src/Shared/AggregatedPlayerStatsTable.tsx
+++ b/src/Shared/AggregatedPlayerStatsTable.tsx
@@ -35,9 +35,13 @@ function AggregatePlayerStatsRow({
       <td className="position-span"></td>
 
       <td className="player">
-        <Link to={`${playerViewBasePath}${playerStatLog.playerId}`}>
-          {playerName}
-        </Link>
+        {playerStatLog.playerId ? (
+          <Link to={`${playerViewBasePath}${playerStatLog.playerId}`}>
+            {playerName}
+          </Link>
+        ) : (
+          playerName
+        )}
       </td>
 
       <td className="player-span"></td>

--- a/src/Shared/GameBoxScoreTable.tsx
+++ b/src/Shared/GameBoxScoreTable.tsx
@@ -25,9 +25,13 @@ function GameBoxScorePlayerRow({
   return (
     <tr>
       <td className="player">
-        <Link to={`${playerViewBasePath}${playerStatLog.playerId}`}>
-          {playerName}
-        </Link>
+        {playerStatLog.playerId ? (
+          <Link to={`${playerViewBasePath}${playerStatLog.playerId}`}>
+            {playerName}
+          </Link>
+        ) : (
+          playerName
+        )}
       </td>
 
       <td className="player-span"></td>


### PR DESCRIPTION
## Summary
Copilot's review on #101 (TypeScript 3.4.5 → 4.9.5 upgrade) flagged 8 findings. All 8 were verified against the pre-upgrade code (`git show` on `master`) and confirmed to be **pre-existing bugs**, not regressions introduced by the TS upgrade — the upgrade only added type casts to compile the same already-broken runtime behavior under stricter checking. Since fixing them changes behavior, they were kept out of #101 (whose scope is compiler-driven fixes only, no behavior change) and are fixed here instead, independent of that PR.

- `TeamRosterInvites.tsx`: stop feeding a camelCase `TournamentEntity` default into a mapper that expects snake_case API fields when a registration has no tournament.
- `Registrations/dataMappers.ts`: fall back a missing custom field `id` to its `label` instead of `''`, reducing key/lookup collisions across multiple fields.
- `RegistrationResponseView.tsx` / `RegistrationResponseFieldDisplay.tsx`: stop treating a boolean `false` consent response as "missing" — it was rendering blank and the `Consent` field's "not accepted" icon never showed.
- `AggregatedPlayerStatsTable.tsx`, `GameBoxScoreTable.tsx`, `PlayerStatsLog/View.tsx`: don't render a `Link` to a player view when `playerId` is missing (was producing a route ending in `undefined`).
- `OfficialProfileSearchResults.tsx`: disable the invite button when the official profile has no `id`, instead of inviting with an empty string.