### PR TITLE
chore: enable eslint no-explicit-any and remove all any usage

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,6 +1,7 @@
 {
   "extends": "react-app",
   "rules": {
-    "@typescript-eslint/no-unused-vars": "error"
+    "@typescript-eslint/no-unused-vars": "error",
+    "@typescript-eslint/no-explicit-any": "error"
   }
 }

--- a/src/Accounts/actions.ts
+++ b/src/Accounts/actions.ts
@@ -31,7 +31,7 @@ export const signInSuccess = (
   payload
 });
 
-export const signInFailure = (payload: any): HttpAction<ActionTypes> => ({
+export const signInFailure = (payload: unknown): HttpAction<ActionTypes> => ({
   type: SIGN_IN_FAILURE,
   payload
 });
@@ -47,7 +47,7 @@ export const signUpSuccess = (
   payload
 });
 
-export const signUpFailure = (payload: any): HttpAction<ActionTypes> => ({
+export const signUpFailure = (payload: unknown): HttpAction<ActionTypes> => ({
   type: SIGN_UP_FAILURE,
   payload
 });
@@ -60,7 +60,9 @@ export const accountResetSuccess = (): HttpAction<ActionTypes> => ({
   type: ACCOUNT_RESET_SUCCESS
 });
 
-export const accountResetFailure = (payload: any): HttpAction<ActionTypes> => ({
+export const accountResetFailure = (
+  payload: unknown
+): HttpAction<ActionTypes> => ({
   type: ACCOUNT_RESET_FAILURE,
   payload
 });
@@ -74,7 +76,7 @@ export const accountRecoverySuccess = (): HttpAction<ActionTypes> => ({
 });
 
 export const accountRecoveryFailure = (
-  payload: any
+  payload: unknown
 ): HttpAction<ActionTypes> => ({
   type: ACCOUNT_RECOVERY_FAILURE,
   payload
@@ -91,7 +93,9 @@ export const getAccountSuccess = (
   payload
 });
 
-export const getAccountFailure = (payload: any): HttpAction<ActionTypes> => ({
+export const getAccountFailure = (
+  payload: unknown
+): HttpAction<ActionTypes> => ({
   type: GET_ACCOUNT_FAILURE,
   payload
 });

--- a/src/Accounts/effects.ts
+++ b/src/Accounts/effects.ts
@@ -1,5 +1,9 @@
 import { Dispatch } from 'redux';
 import {
+  ReactFacebookFailureResponse,
+  ReactFacebookLoginInfo
+} from 'react-facebook-login';
+import {
   SignInEntity,
   SignUpEntity,
   AccountRecoveryEntity,
@@ -127,9 +131,9 @@ export const facebookSignUp = (
 };
 
 export const redirectToFacebookSignUp = (history: History) => async (
-  facebookResponse: any
+  facebookResponse: ReactFacebookLoginInfo | ReactFacebookFailureResponse
 ) => {
-  if (facebookResponse.status) {
+  if (!('id' in facebookResponse)) {
     displayToast(`Sign up failed :(`, 'is-primary');
     return;
   }

--- a/src/AggregatedPlayerStats/actions.ts
+++ b/src/AggregatedPlayerStats/actions.ts
@@ -20,7 +20,7 @@ export const getAggregatedPlayerStatsLogsByFilterSuccess = (
 });
 
 export const getAggregatedPlayerStatsLogsByFilterFailure = (
-  payload: any
+  payload: unknown
 ): HttpAction<ActionTypes> => ({
   type: GET_AGGREGATED_PLAYER_STATS_LOGS_BY_FILTER_FAILURE,
   payload

--- a/src/AthleteProfiles/actions.ts
+++ b/src/AthleteProfiles/actions.ts
@@ -33,7 +33,7 @@ export const deleteAthleteProfileSuccess = (username: string) => ({
   payload: username
 });
 
-export const deleteAthleteProfileFailure = (error: any) => ({
+export const deleteAthleteProfileFailure = (error: unknown) => ({
   type: DELETE_ATHLETE_PROFILE_FAILURE,
   payload: error
 });
@@ -49,7 +49,7 @@ export const patchAthleteProfileSuccess = (
   payload: athleteProfile
 });
 
-export const patchAthleteProfileFailure = (error: any) => ({
+export const patchAthleteProfileFailure = (error: unknown) => ({
   type: PATCH_ATHLETE_PROFILE_FAILURE,
   payload: error
 });
@@ -65,7 +65,7 @@ export const postAthleteProfileSuccess = (
   payload: athleteProfile
 });
 
-export const postAthleteProfileFailure = (error: any) => ({
+export const postAthleteProfileFailure = (error: unknown) => ({
   type: POST_ATHLETE_PROFILE_FAILURE,
   payload: error
 });
@@ -81,7 +81,7 @@ export const requestAthleteProfileSuccess = (
   payload: athleteProfile
 });
 
-export const requestAthleteProfileFailure = (error: any) => ({
+export const requestAthleteProfileFailure = (error: unknown) => ({
   type: REQUEST_ATHLETE_PROFILE_FAILURE,
   payload: error
 });
@@ -97,7 +97,7 @@ export const requestAthleteProfilesSuccess = (
   payload: athleteProfiles
 });
 
-export const requestAthleteProfilesFailure = (error: any) => ({
+export const requestAthleteProfilesFailure = (error: unknown) => ({
   type: REQUEST_ATHLETE_PROFILES_FAILURE,
   payload: error
 });

--- a/src/AthleteProfiles/athleteProfileHttpClient.ts
+++ b/src/AthleteProfiles/athleteProfileHttpClient.ts
@@ -12,7 +12,8 @@ const ATHLETE_PROFILES_API = `${REACT_APP_API_HOST}v1/athlete-profiles`;
 const slug = (username = '') => `${ATHLETE_PROFILES_API}/username/${username}`;
 
 const athleteProfileHttpClient = {
-  delete: (username: string): Promise<any> => httpClient.delete(slug(username)),
+  delete: (username: string): Promise<string> =>
+    httpClient.delete(slug(username)),
   get: (username: string): Promise<ApiAthleteProfileResponse> =>
     httpClient.get(slug(username)),
   patch: (

--- a/src/Draws/Form.tsx
+++ b/src/Draws/Form.tsx
@@ -243,7 +243,7 @@ const MatchForm: React.FC<MatchFormProps> = ({
 };
 
 interface FieldArrayActions {
-  value: any[];
+  value: unknown[];
   remove: (index: number) => void;
   swap: (indexA: number, indexB: number) => void;
 }

--- a/src/Draws/Form.tsx
+++ b/src/Draws/Form.tsx
@@ -243,7 +243,7 @@ const MatchForm: React.FC<MatchFormProps> = ({
 };
 
 interface FieldArrayActions {
-  value: unknown[];
+  value: DrawMatchEntity[];
   remove: (index: number) => void;
   swap: (indexA: number, indexB: number) => void;
 }

--- a/src/Draws/actions.ts
+++ b/src/Draws/actions.ts
@@ -24,7 +24,9 @@ export const deleteDrawSuccess = (
   payload
 });
 
-export const deleteDrawFailure = (payload: any): HttpAction<ActionTypes> => ({
+export const deleteDrawFailure = (
+  payload: unknown
+): HttpAction<ActionTypes> => ({
   type: DELETE_DRAW_FAILURE,
   payload
 });
@@ -47,7 +49,9 @@ export const batchPatchDrawSuccess = (
   payload: payload
 });
 
-export const patchDrawFailure = (payload: any): HttpAction<ActionTypes> => ({
+export const patchDrawFailure = (
+  payload: unknown
+): HttpAction<ActionTypes> => ({
   type: PATCH_DRAW_FAILURE,
   payload
 });
@@ -63,7 +67,7 @@ export const postDrawSuccess = (
   payload
 });
 
-export const postDrawFailure = (payload: any): HttpAction<ActionTypes> => ({
+export const postDrawFailure = (payload: unknown): HttpAction<ActionTypes> => ({
   type: POST_DRAW_FAILURE,
   payload
 });

--- a/src/Eliminations/Form.tsx
+++ b/src/Eliminations/Form.tsx
@@ -155,7 +155,7 @@ const StatHeader: React.FC<{
 }> = ({ stat }) => <th className="has-text-centered">{stat.title}</th>;
 
 interface FieldArrayActions {
-  value: unknown[];
+  value: EliminationTeamStatEntity[];
   remove: (index: number) => void;
   swap: (indexA: number, indexB: number) => void;
 }

--- a/src/Eliminations/Form.tsx
+++ b/src/Eliminations/Form.tsx
@@ -155,7 +155,7 @@ const StatHeader: React.FC<{
 }> = ({ stat }) => <th className="has-text-centered">{stat.title}</th>;
 
 interface FieldArrayActions {
-  value: any[];
+  value: unknown[];
   remove: (index: number) => void;
   swap: (indexA: number, indexB: number) => void;
 }

--- a/src/Eliminations/actions.ts
+++ b/src/Eliminations/actions.ts
@@ -26,7 +26,7 @@ export const deleteEliminationSuccess = (
 });
 
 export const deleteEliminationFailure = (
-  payload: any
+  payload: unknown
 ): HttpAction<ActionTypes> => ({
   type: DELETE_ELIMINATION_FAILURE,
   payload
@@ -51,7 +51,7 @@ export const batchPatchEliminationSuccess = (
 });
 
 export const patchEliminationFailure = (
-  payload: any
+  payload: unknown
 ): HttpAction<ActionTypes> => ({
   type: PATCH_ELIMINATION_FAILURE,
   payload
@@ -69,7 +69,7 @@ export const postEliminationSuccess = (
 });
 
 export const postEliminationFailure = (
-  payload: any
+  payload: unknown
 ): HttpAction<ActionTypes> => ({
   type: POST_ELIMINATION_FAILURE,
   payload

--- a/src/FixedPlayerStatsTables/Form.tsx
+++ b/src/FixedPlayerStatsTables/Form.tsx
@@ -97,7 +97,7 @@ const FixedPlayerStatsRow: React.FC<FixedPlayerStatsRowProps> = ({
 };
 
 interface FieldArrayActions {
-  value: unknown[];
+  value: FixedPlayerStatsRecordEntity[];
   remove: (index: number) => void;
   swap: (indexA: number, indexB: number) => void;
 }

--- a/src/FixedPlayerStatsTables/Form.tsx
+++ b/src/FixedPlayerStatsTables/Form.tsx
@@ -97,7 +97,7 @@ const FixedPlayerStatsRow: React.FC<FixedPlayerStatsRowProps> = ({
 };
 
 interface FieldArrayActions {
-  value: any[];
+  value: unknown[];
   remove: (index: number) => void;
   swap: (indexA: number, indexB: number) => void;
 }

--- a/src/FixedPlayerStatsTables/actions.ts
+++ b/src/FixedPlayerStatsTables/actions.ts
@@ -38,7 +38,7 @@ export const deleteFixedPlayerStatsTableSuccess = (
 });
 
 export const deleteFixedPlayerStatsTableFailure = (
-  payload: any
+  payload: unknown
 ): HttpAction<ActionTypes> => ({
   type: DELETE_FIXED_PLAYER_STATS_TABLE_FAILURE,
   payload
@@ -56,7 +56,7 @@ export const patchFixedPlayerStatsTableSuccess = (
 });
 
 export const patchFixedPlayerStatsTableFailure = (
-  payload: any
+  payload: unknown
 ): HttpAction<ActionTypes> => ({
   type: PATCH_FIXED_PLAYER_STATS_TABLE_FAILURE,
   payload
@@ -74,7 +74,7 @@ export const postFixedPlayerStatsTableSuccess = (
 });
 
 export const postFixedPlayerStatsTableFailure = (
-  payload: any
+  payload: unknown
 ): HttpAction<ActionTypes> => ({
   type: POST_FIXED_PLAYER_STATS_TABLE_FAILURE,
   payload
@@ -85,14 +85,14 @@ export const getFixedPlayerStatsTablesByFilterStart = (): HttpAction<ActionTypes
 });
 
 export const getFixedPlayerStatsTablesByFilterSuccess = (
-  payload: any
+  payload: FixedPlayerStatsTableEntity[]
 ): HttpAction<ActionTypes, FixedPlayerStatsTableEntity[]> => ({
   type: GET_FIXED_PLAYER_STATS_TABLES_BY_FILTER_SUCCESS,
   payload
 });
 
 export const getFixedPlayerStatsTablesByFilterFailure = (
-  payload: any
+  payload: unknown
 ): HttpAction<ActionTypes> => ({
   type: GET_FIXED_PLAYER_STATS_TABLES_BY_FILTER_FAILURE,
   payload

--- a/src/Games/List.tsx
+++ b/src/Games/List.tsx
@@ -33,7 +33,9 @@ export const ListLoading: React.FC = () => (
 );
 
 const GameCard: React.FC<{
-  onDeleteGame: any;
+  onDeleteGame: (
+    game: GameEntity
+  ) => (dispatch: Dispatch<AnyAction>) => Promise<void>;
   url: string;
   game: GameEntity;
 }> = ({ onDeleteGame, url, game }) => {

--- a/src/Games/actions.ts
+++ b/src/Games/actions.ts
@@ -28,12 +28,16 @@ export const deleteGameStart = (): HttpAction<ActionTypes> => ({
   type: DELETE_TOURNAMENT_GAME
 });
 
-export const deleteGameSuccess = (payload: any): HttpAction<ActionTypes> => ({
+export const deleteGameSuccess = (
+  payload: string
+): HttpAction<ActionTypes, string> => ({
   type: DELETE_TOURNAMENT_GAME_SUCCESS,
   payload
 });
 
-export const deleteGameFailure = (payload: any): HttpAction<ActionTypes> => ({
+export const deleteGameFailure = (
+  payload: unknown
+): HttpAction<ActionTypes> => ({
   type: DELETE_TOURNAMENT_GAME_FAILURE,
   payload
 });
@@ -49,7 +53,9 @@ export const patchGameSuccess = (
   payload
 });
 
-export const patchGameFailure = (payload: any): HttpAction<ActionTypes> => ({
+export const patchGameFailure = (
+  payload: unknown
+): HttpAction<ActionTypes> => ({
   type: PATCH_TOURNAMENT_GAME_FAILURE,
   payload
 });
@@ -58,12 +64,12 @@ export const postGameStart = (): HttpAction<ActionTypes> => ({
   type: POST_TOURNAMENT_GAME
 });
 
-export const postGameSuccess = (payload: any): HttpAction<ActionTypes> => ({
+export const postGameSuccess = (payload: unknown): HttpAction<ActionTypes> => ({
   type: POST_TOURNAMENT_GAME_SUCCESS,
   payload
 });
 
-export const postGameFailure = (payload: any): HttpAction<ActionTypes> => ({
+export const postGameFailure = (payload: unknown): HttpAction<ActionTypes> => ({
   type: POST_TOURNAMENT_GAME_FAILURE,
   payload
 });
@@ -79,7 +85,7 @@ export const getGameSuccess = (
   payload
 });
 
-export const getGameFailure = (payload: any): HttpAction<ActionTypes> => ({
+export const getGameFailure = (payload: unknown): HttpAction<ActionTypes> => ({
   type: GET_TOURNAMENT_GAME_FAILURE,
   payload
 });
@@ -89,14 +95,14 @@ export const getGamesByFilterStart = (): HttpAction<ActionTypes> => ({
 });
 
 export const getGamesByFilterSuccess = (
-  payload: any
+  payload: unknown
 ): HttpAction<ActionTypes> => ({
   type: GET_TOURNAMENT_GAMES_BY_FILTER_SUCCESS,
   payload
 });
 
 export const getGamesByFilterFailure = (
-  payload: any
+  payload: unknown
 ): HttpAction<ActionTypes> => ({
   type: GET_TOURNAMENT_GAMES_BY_FILTER_FAILURE,
   payload

--- a/src/Games/actions.ts
+++ b/src/Games/actions.ts
@@ -48,7 +48,7 @@ export const patchGameStart = (): HttpAction<ActionTypes> => ({
 
 export const patchGameSuccess = (
   payload: GameEntity
-): HttpAction<ActionTypes> => ({
+): HttpAction<ActionTypes, GameEntity> => ({
   type: PATCH_TOURNAMENT_GAME_SUCCESS,
   payload
 });
@@ -64,7 +64,9 @@ export const postGameStart = (): HttpAction<ActionTypes> => ({
   type: POST_TOURNAMENT_GAME
 });
 
-export const postGameSuccess = (payload: unknown): HttpAction<ActionTypes> => ({
+export const postGameSuccess = (
+  payload: GameEntity
+): HttpAction<ActionTypes, GameEntity> => ({
   type: POST_TOURNAMENT_GAME_SUCCESS,
   payload
 });
@@ -80,7 +82,7 @@ export const getGameStart = (): HttpAction<ActionTypes> => ({
 
 export const getGameSuccess = (
   payload: GameEntity
-): HttpAction<ActionTypes> => ({
+): HttpAction<ActionTypes, GameEntity> => ({
   type: GET_TOURNAMENT_GAME_SUCCESS,
   payload
 });
@@ -95,8 +97,8 @@ export const getGamesByFilterStart = (): HttpAction<ActionTypes> => ({
 });
 
 export const getGamesByFilterSuccess = (
-  payload: unknown
-): HttpAction<ActionTypes> => ({
+  payload: GameEntity[]
+): HttpAction<ActionTypes, GameEntity[]> => ({
   type: GET_TOURNAMENT_GAMES_BY_FILTER_SUCCESS,
   payload
 });

--- a/src/Games/dataMappers.test.ts
+++ b/src/Games/dataMappers.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-explicit-any -- simulating malformed API responses that violate the declared (non-nullable) types */
 import {
   ApiGameWithDepedencies,
   ApiGamePostRequest,

--- a/src/Games/reducer.test.ts
+++ b/src/Games/reducer.test.ts
@@ -256,22 +256,23 @@ describe('postGameFailure', () => {
 
 describe('postGameSuccess', () => {
   const action = postGameSuccess({
+    ...DEFAULT_GAME,
     id: 'first-id',
     awayPlaceholder: 'first away placeholder',
     awayScore: 10,
     awayTeam: {
+      ...DEFAULT_TEAM,
       id: 'first-away-team-id',
-      name: 'first-away-team',
-      stats: {}
+      name: 'first-away-team'
     },
     city: 'first city',
     datetime: '2019-05-22T03:21:21.248Z',
     homePlaceholder: 'first home placeholder',
     homeScore: 20,
     homeTeam: {
+      ...DEFAULT_TEAM,
       id: 'first-home-team-id',
-      name: 'first-home-team',
-      stats: {}
+      name: 'first-home-team'
     },
     location: 'first location',
     number: 'first number',
@@ -286,22 +287,23 @@ describe('postGameSuccess', () => {
     const newState = gameReducer(initialState, action);
 
     expect(newState.games['first-id']).toEqual({
+      ...DEFAULT_GAME,
       id: 'first-id',
       awayPlaceholder: 'first away placeholder',
       awayScore: 10,
       awayTeam: {
+        ...DEFAULT_TEAM,
         id: 'first-away-team-id',
-        name: 'first-away-team',
-        stats: {}
+        name: 'first-away-team'
       },
       city: 'first city',
       datetime: '2019-05-22T03:21:21.248Z',
       homePlaceholder: 'first home placeholder',
       homeScore: 20,
       homeTeam: {
+        ...DEFAULT_TEAM,
         id: 'first-home-team-id',
-        name: 'first-home-team',
-        stats: {}
+        name: 'first-home-team'
       },
       location: 'first location',
       number: 'first number',
@@ -442,7 +444,9 @@ describe('getGamesByFilterFailure', () => {
 });
 
 describe('getGamesByFilterSuccess', () => {
-  const action = getGamesByFilterSuccess([
+  // Deliberately partial/null fixtures to exercise the reducer's merge behavior
+  // with incomplete entities, not full GameEntity correctness.
+  const action = getGamesByFilterSuccess(([
     {
       id: 'first-id',
       awayScore: 10,
@@ -487,7 +491,7 @@ describe('getGamesByFilterSuccess', () => {
       location: 'third location',
       number: 'third number'
     }
-  ]);
+  ] as unknown) as GameEntity[]);
 
   it('sets isLoadingRequestGames to false', () => {
     expect(gameReducer(initialState, action).isLoadingRequestGames).toBe(false);

--- a/src/Games/reducer.ts
+++ b/src/Games/reducer.ts
@@ -43,10 +43,10 @@ const deleteGameFailure = (
 
 const deleteGameSuccess = (
   state: GameState,
-  action: HttpAction<ActionTypes>
+  action: HttpAction<ActionTypes, string>
 ) => {
   const games = Object.keys(state.games)
-    .filter(entityById(state.games, action.payload))
+    .filter(entityById(state.games, action.payload || ''))
     .reduce(mapEntitiesByKey(state.games), {});
   return {
     ...state,

--- a/src/Games/useGameStatsLogs.test.ts
+++ b/src/Games/useGameStatsLogs.test.ts
@@ -1,4 +1,4 @@
-import { FetchingStrategy } from './useGameStatsLogs';
+import { FetchingStrategy, stringifyStats } from './useGameStatsLogs';
 import { GameEntity } from './state';
 import { TeamEntity } from '../Teams/state';
 import { PlayerStatsLogEntity } from '../PlayerStatsLog/state';
@@ -220,6 +220,71 @@ const mockApiGameData = {
   sport_id: 'basketball',
   view_settings_state: {}
 };
+
+describe('stringifyStats', () => {
+  it('converts numeric stat values to strings', () => {
+    expect(stringifyStats({ points: 12, rebounds: 6, assists: 2 })).toEqual({
+      points: '12',
+      rebounds: '6',
+      assists: '2'
+    });
+  });
+
+  it('keeps zero as "0" instead of dropping it', () => {
+    // The scoreboard API sends 0 for stats a player has not recorded, and the
+    // box score must render "0", not a blank cell.
+    const result = stringifyStats({ points: 0, blocks: 0, steals: 3 });
+
+    expect(result).toEqual({ points: '0', blocks: '0', steals: '3' });
+    expect(result.points).not.toBe('');
+  });
+
+  it('handles negative and decimal values', () => {
+    expect(
+      stringifyStats({ plus_minus: -7, field_goal_percentage: 66.7 })
+    ).toEqual({
+      plus_minus: '-7',
+      field_goal_percentage: '66.7'
+    });
+  });
+
+  it('returns an empty object when stats is undefined', () => {
+    expect(stringifyStats(undefined)).toEqual({});
+  });
+
+  it('returns an empty object when stats is empty', () => {
+    expect(stringifyStats({})).toEqual({});
+  });
+
+  it('preserves every key it is given', () => {
+    const stats = { a: 1, b: 2, c: 3, d: 4 };
+
+    expect(Object.keys(stringifyStats(stats))).toEqual(['a', 'b', 'c', 'd']);
+  });
+
+  it('does not mutate the input object', () => {
+    const stats = { points: 12 };
+
+    stringifyStats(stats);
+
+    expect(stats).toEqual({ points: 12 });
+  });
+
+  it('converts a full API stats_values payload', () => {
+    const apiStatsValues = mockApiGameData.away_team.players[0].stats_values;
+
+    const result = stringifyStats(apiStatsValues);
+
+    expect(result.points).toBe('12');
+    expect(result.rebounds).toBe('6');
+    expect(result.minutes_played).toBe('25');
+    expect(result.blocks).toBe('0');
+    expect(Object.keys(result)).toHaveLength(
+      Object.keys(apiStatsValues).length
+    );
+    expect(Object.values(result).every(v => typeof v === 'string')).toBe(true);
+  });
+});
 
 describe('useGameStatsLogs', () => {
   beforeEach(() => {

--- a/src/Games/useGameStatsLogs.ts
+++ b/src/Games/useGameStatsLogs.ts
@@ -22,9 +22,7 @@ export interface GameStatsData {
   error: string | null;
 }
 
-const stringifyStats = (
-  stats: Record<string, number> | undefined
-): { [id: string]: string } =>
+const stringifyStats = (stats: object | undefined): { [id: string]: string } =>
   Object.entries(stats || {}).reduce(
     (acc, [key, value]) => ({ ...acc, [key]: String(value) }),
     {} as { [id: string]: string }
@@ -37,9 +35,7 @@ const mapApiPlayerToStatsLogRenderEntity = (
   id: apiPlayer.id,
   playerId: apiPlayer.id,
   teamId,
-  stats: stringifyStats(
-    (apiPlayer.stats_values as unknown) as Record<string, number>
-  )
+  stats: stringifyStats(apiPlayer.stats_values)
 });
 
 const mapApiTeamToStatsLogRenderEntity = (

--- a/src/Games/useGameStatsLogs.ts
+++ b/src/Games/useGameStatsLogs.ts
@@ -6,6 +6,7 @@ import { StatsLogRenderEntity } from '../PlayerStatsLog/View';
 import playerStatsLogHttpClient from '../PlayerStatsLog/playerStatsLogHttpClient';
 import teamStatsLogHttpClient from '../TeamStatsLog/teamStatsLogHttpClient';
 import scoreboardApiHttpClient from '../Shared/httpClient/scoreboardApiHttpClient';
+import { ApiPlayer, ApiTeam } from '../Shared/httpClient/scoreboardApiTypes';
 
 const POLLING_INTERVAL = 10000; // 10 seconds
 
@@ -21,23 +22,33 @@ export interface GameStatsData {
   error: string | null;
 }
 
+const stringifyStats = (
+  stats: Record<string, number> | undefined
+): { [id: string]: string } =>
+  Object.entries(stats || {}).reduce(
+    (acc, [key, value]) => ({ ...acc, [key]: String(value) }),
+    {} as { [id: string]: string }
+  );
+
 const mapApiPlayerToStatsLogRenderEntity = (
-  apiPlayer: any,
+  apiPlayer: ApiPlayer,
   teamId: string
 ): StatsLogRenderEntity => ({
   id: apiPlayer.id,
   playerId: apiPlayer.id,
   teamId,
-  stats: apiPlayer.stats_values || {}
+  stats: stringifyStats(
+    (apiPlayer.stats_values as unknown) as Record<string, number>
+  )
 });
 
 const mapApiTeamToStatsLogRenderEntity = (
-  apiTeam: any,
+  apiTeam: ApiTeam,
   teamId: string
 ): StatsLogRenderEntity => ({
   id: teamId,
   teamId,
-  stats: apiTeam.total_player_stats || {}
+  stats: stringifyStats(apiTeam.total_player_stats)
 });
 
 const mapPlayerStatsLogToRenderEntity = (
@@ -137,14 +148,12 @@ export const useGameStatsLogs = (game: GameEntity): GameStatsData => {
       const gameData = await scoreboardApiHttpClient.getGame(game.id);
 
       // Map API data to render entities
-      const awayPlayerStatsLogs = gameData.away_team.players.map(
-        (player: any) =>
-          mapApiPlayerToStatsLogRenderEntity(player, game.awayTeam.id)
+      const awayPlayerStatsLogs = gameData.away_team.players.map(player =>
+        mapApiPlayerToStatsLogRenderEntity(player, game.awayTeam.id)
       );
 
-      const homePlayerStatsLogs = gameData.home_team.players.map(
-        (player: any) =>
-          mapApiPlayerToStatsLogRenderEntity(player, game.homeTeam.id)
+      const homePlayerStatsLogs = gameData.home_team.players.map(player =>
+        mapApiPlayerToStatsLogRenderEntity(player, game.homeTeam.id)
       );
 
       const awayTeamStatsLog = mapApiTeamToStatsLogRenderEntity(

--- a/src/Games/useGameStatsLogs.ts
+++ b/src/Games/useGameStatsLogs.ts
@@ -22,7 +22,9 @@ export interface GameStatsData {
   error: string | null;
 }
 
-const stringifyStats = (stats: object | undefined): { [id: string]: string } =>
+export const stringifyStats = (
+  stats: object | undefined
+): { [id: string]: string } =>
   Object.entries(stats || {}).reduce(
     (acc, [key, value]) => ({ ...acc, [key]: String(value) }),
     {} as { [id: string]: string }

--- a/src/OfficialProfiles/actions.ts
+++ b/src/OfficialProfiles/actions.ts
@@ -49,7 +49,7 @@ export const deleteOfficialProfileSuccess = (username: string) => ({
   payload: username
 });
 
-export const deleteOfficialProfileFailure = (error: any) => ({
+export const deleteOfficialProfileFailure = (error: unknown) => ({
   type: DELETE_OFFICIAL_PROFILE_FAILURE,
   payload: error
 });
@@ -65,7 +65,7 @@ export const patchOfficialProfileSuccess = (
   payload: officialProfile
 });
 
-export const patchOfficialProfileFailure = (error: any) => ({
+export const patchOfficialProfileFailure = (error: unknown) => ({
   type: PATCH_OFFICIAL_PROFILE_FAILURE,
   payload: error
 });
@@ -79,7 +79,7 @@ export const patchOfficialProfileSignatureSuccess = (username: string) => ({
   payload: username
 });
 
-export const patchOfficialProfileSignatureFailure = (error: any) => ({
+export const patchOfficialProfileSignatureFailure = (error: unknown) => ({
   type: PATCH_OFFICIAL_PROFILE_SIGNATURE_FAILURE,
   payload: error
 });
@@ -95,7 +95,7 @@ export const postOfficialProfileSuccess = (
   payload: officialProfile
 });
 
-export const postOfficialProfileFailure = (error: any) => ({
+export const postOfficialProfileFailure = (error: unknown) => ({
   type: POST_OFFICIAL_PROFILE_FAILURE,
   payload: error
 });
@@ -111,7 +111,7 @@ export const requestOfficialProfileSuccess = (
   payload: officialProfile
 });
 
-export const requestOfficialProfileFailure = (error: any) => ({
+export const requestOfficialProfileFailure = (error: unknown) => ({
   type: REQUEST_OFFICIAL_PROFILE_FAILURE,
   payload: error
 });
@@ -127,7 +127,7 @@ export const requestOfficialProfilesSuccess = (
   payload: officialProfiles
 });
 
-export const requestOfficialProfilesFailure = (error: any) => ({
+export const requestOfficialProfilesFailure = (error: unknown) => ({
   type: REQUEST_OFFICIAL_PROFILES_FAILURE,
   payload: error
 });
@@ -140,7 +140,7 @@ export const approveOfficialProfileInviteSuccess = () => ({
   type: APPROVE_OFFICIAL_PROFILE_INVITE_SUCCESS
 });
 
-export const approveOfficialProfileInviteFailure = (error: any) => ({
+export const approveOfficialProfileInviteFailure = (error: unknown) => ({
   type: APPROVE_OFFICIAL_PROFILE_INVITE_FAILURE,
   payload: error
 });

--- a/src/OfficialProfiles/dataMappers.test.ts
+++ b/src/OfficialProfiles/dataMappers.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-explicit-any -- partial tournament fixtures that intentionally omit unrelated fields */
 import {
   mapApiOfficialProfileToOfficialProfileEntity,
   mapOfficialProfileEntityToApiOfficialProfilePatchRequest,

--- a/src/OfficialProfiles/effects.ts
+++ b/src/OfficialProfiles/effects.ts
@@ -31,7 +31,7 @@ import {
 import officialProfileHttpClient from './officialProfileHttpClient';
 import { OfficialProfileEntity } from './state';
 import { displayToast } from '../Shared/bulma/toast';
-import ApiError from '../Shared/httpClient/ApiError';
+import ApiError, { ApiDataError } from '../Shared/httpClient/ApiError';
 
 export const deleteOfficialProfile = (username: string) => async (
   dispatch: Dispatch
@@ -44,7 +44,7 @@ export const deleteOfficialProfile = (username: string) => async (
     dispatch(deleteOfficialProfileSuccess(username));
     displayToast('Official profile deleted!', 'is-success');
   } catch (err) {
-    const apiError = new ApiError(err as any);
+    const apiError = new ApiError(err as ApiDataError);
     dispatch(deleteOfficialProfileFailure(err));
     displayToast(apiError.message, 'is-danger');
   }
@@ -71,7 +71,7 @@ export const patchOfficialProfile = (
     dispatch(patchOfficialProfileSuccess(updatedOfficialProfile));
     displayToast('Official profile updated!', 'is-success');
   } catch (err) {
-    const apiError = new ApiError(err as any);
+    const apiError = new ApiError(err as ApiDataError);
     dispatch(patchOfficialProfileFailure(err));
     displayToast(apiError.message, 'is-danger');
   }
@@ -95,7 +95,7 @@ export const patchOfficialProfileSignature = (
     displayToast('Signature updated!', 'is-success');
     history.push(`/Account/EditOfficialProfile/${username}`);
   } catch (err) {
-    const apiError = new ApiError(err as any);
+    const apiError = new ApiError(err as ApiDataError);
     dispatch(patchOfficialProfileSignatureFailure(err));
     displayToast(apiError.message, 'is-danger');
   }
@@ -121,7 +121,7 @@ export const postOfficialProfile = (
     dispatch(postOfficialProfileSuccess(newOfficialProfile));
     displayToast('Official profile created!', 'is-success');
   } catch (err) {
-    const apiError = new ApiError(err as any);
+    const apiError = new ApiError(err as ApiDataError);
     dispatch(postOfficialProfileFailure(err));
     displayToast(apiError.message, 'is-danger');
   }
@@ -174,7 +174,7 @@ export const approveOfficialProfileInvite = (
     // Refresh the official profile to update pending invites
     await requestOfficialProfile(username)(dispatch);
   } catch (err) {
-    const apiError = new ApiError(err as any);
+    const apiError = new ApiError(err as ApiDataError);
     dispatch(approveOfficialProfileInviteFailure(err));
     displayToast(apiError.message, 'is-danger');
   }

--- a/src/OfficialProfiles/officialProfileHttpClient.ts
+++ b/src/OfficialProfiles/officialProfileHttpClient.ts
@@ -19,7 +19,8 @@ const OFFICIAL_PROFILES_API = `${REACT_APP_API_HOST}v1/official-profiles`;
 const slug = (username = '') => `${OFFICIAL_PROFILES_API}/username/${username}`;
 
 const officialProfileHttpClient = {
-  delete: (username: string): Promise<any> => httpClient.delete(slug(username)),
+  delete: (username: string): Promise<string> =>
+    httpClient.delete(slug(username)),
   get: (username: string): Promise<ApiOfficialProfileResponse> =>
     httpClient.get(slug(username)),
   patch: (

--- a/src/Officials/actions.ts
+++ b/src/Officials/actions.ts
@@ -1,3 +1,5 @@
+import { OfficialEntity } from './state';
+
 export enum ActionTypes {
   DELETE_OFFICIAL_FAILURE = 'DELETE_OFFICIAL_FAILURE',
   DELETE_OFFICIAL_START = 'DELETE_OFFICIAL_START',
@@ -33,7 +35,7 @@ export const patchOfficialStart = () => ({
   type: ActionTypes.PATCH_OFFICIAL_START
 });
 
-export const patchOfficialSuccess = (payload: unknown) => ({
+export const patchOfficialSuccess = (payload: OfficialEntity) => ({
   type: ActionTypes.PATCH_OFFICIAL_SUCCESS,
   payload
 });
@@ -47,7 +49,7 @@ export const postOfficialStart = () => ({
   type: ActionTypes.POST_OFFICIAL_START
 });
 
-export const postOfficialSuccess = (payload: unknown) => ({
+export const postOfficialSuccess = (payload: OfficialEntity) => ({
   type: ActionTypes.POST_OFFICIAL_SUCCESS,
   payload
 });

--- a/src/Officials/actions.ts
+++ b/src/Officials/actions.ts
@@ -10,7 +10,7 @@ export enum ActionTypes {
   POST_OFFICIAL_SUCCESS = 'POST_OFFICIAL_SUCCESS'
 }
 
-export const deleteOfficialFailure = (payload: any) => ({
+export const deleteOfficialFailure = (payload: unknown) => ({
   type: ActionTypes.DELETE_OFFICIAL_FAILURE,
   payload
 });
@@ -24,7 +24,7 @@ export const deleteOfficialSuccess = (payload: string) => ({
   payload
 });
 
-export const patchOfficialFailure = (payload: any) => ({
+export const patchOfficialFailure = (payload: unknown) => ({
   type: ActionTypes.PATCH_OFFICIAL_FAILURE,
   payload
 });
@@ -33,12 +33,12 @@ export const patchOfficialStart = () => ({
   type: ActionTypes.PATCH_OFFICIAL_START
 });
 
-export const patchOfficialSuccess = (payload: any) => ({
+export const patchOfficialSuccess = (payload: unknown) => ({
   type: ActionTypes.PATCH_OFFICIAL_SUCCESS,
   payload
 });
 
-export const postOfficialFailure = (payload: any) => ({
+export const postOfficialFailure = (payload: unknown) => ({
   type: ActionTypes.POST_OFFICIAL_FAILURE,
   payload
 });
@@ -47,7 +47,7 @@ export const postOfficialStart = () => ({
   type: ActionTypes.POST_OFFICIAL_START
 });
 
-export const postOfficialSuccess = (payload: any) => ({
+export const postOfficialSuccess = (payload: unknown) => ({
   type: ActionTypes.POST_OFFICIAL_SUCCESS,
   payload
 });

--- a/src/Organizations/Form.tsx
+++ b/src/Organizations/Form.tsx
@@ -86,7 +86,7 @@ export const FormLoading: React.FC = () => (
 );
 
 interface FieldArrayActions {
-  value: unknown[];
+  value: MemberEntity[];
   remove: (index: number) => void;
   swap: (indexA: number, indexB: number) => void;
 }

--- a/src/Organizations/Form.tsx
+++ b/src/Organizations/Form.tsx
@@ -86,7 +86,7 @@ export const FormLoading: React.FC = () => (
 );
 
 interface FieldArrayActions {
-  value: any[];
+  value: unknown[];
   remove: (index: number) => void;
   swap: (indexA: number, indexB: number) => void;
 }

--- a/src/Organizations/actions.ts
+++ b/src/Organizations/actions.ts
@@ -30,7 +30,7 @@ export const deleteOrganizationSuccess = (
 });
 
 export const deleteOrganizationFailure = (
-  payload: any
+  payload: unknown
 ): HttpAction<ActionTypes> => ({
   type: DELETE_ORGANIZATION_FAILURE,
   payload
@@ -48,7 +48,7 @@ export const patchOrganizationSuccess = (
 });
 
 export const patchOrganizationFailure = (
-  payload: any
+  payload: unknown
 ): HttpAction<ActionTypes> => ({
   type: PATCH_ORGANIZATION_FAILURE,
   payload
@@ -66,7 +66,7 @@ export const postOrganizationSuccess = (
 });
 
 export const postOrganizationFailure = (
-  payload: any
+  payload: unknown
 ): HttpAction<ActionTypes> => ({
   type: POST_ORGANIZATION_FAILURE,
   payload
@@ -84,7 +84,7 @@ export const getOrganizationSuccess = (
 });
 
 export const getOrganizationFailure = (
-  payload: any
+  payload: unknown
 ): HttpAction<ActionTypes> => ({
   type: GET_ORGANIZATION_FAILURE,
   payload
@@ -102,7 +102,7 @@ export const getOrganizationsSuccess = (
 });
 
 export const getOrganizationsFailure = (
-  payload: any
+  payload: unknown
 ): HttpAction<ActionTypes> => ({
   type: GET_ORGANIZATIONS_FAILURE,
   payload

--- a/src/Pages/PhaseNew.tsx
+++ b/src/Pages/PhaseNew.tsx
@@ -32,6 +32,10 @@ type StateProps = {
 };
 
 type DispatchProps = {
+  getTournamentBySlug: (
+    organizationSlug: string,
+    tournamentSlug: string
+  ) => (dispatch: Dispatch<AnyAction>) => Promise<void>;
   postPhase: (
     phase: PhaseEntity,
     tournamentId: string
@@ -132,4 +136,4 @@ const PhaseNew: React.FC<PhaseNewProps> = ({
   );
 };
 
-export default connector<any>(withTournament<PhaseNewProps>(PhaseNew));
+export default connector(withTournament<PhaseNewProps>(PhaseNew));

--- a/src/Pages/TeamView.tsx
+++ b/src/Pages/TeamView.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { GameEntity } from '../Games/state';
 import Banner from '../Teams/Banner';
 import { tournamentBySlug } from '../Tournaments/selectors';
 import { teamById } from '../Teams/selectors';
@@ -88,7 +89,7 @@ function GamesTab({
   baseUrl
 }: {
   gameDates: string[];
-  gamesByDate: Record<string, any[]>;
+  gamesByDate: Record<string, GameEntity[]>;
   gamesLoading: boolean;
   baseUrl: string;
 }) {

--- a/src/Phases/List.tsx
+++ b/src/Phases/List.tsx
@@ -1,5 +1,6 @@
 import React, { Fragment } from 'react';
 import { Link } from 'react-router-dom';
+import { Dispatch } from 'redux';
 import { PhaseEntity } from './state';
 import Shimmer from '../Shared/UI/Shimmer';
 import DoubleClickButton from '../Shared/UI/DoubleClickButton';
@@ -31,7 +32,7 @@ export const ListLoading: React.FC = () => (
 );
 
 const PhaseCard: React.FC<{
-  onDeletePhase: any;
+  onDeletePhase: (phase: PhaseEntity) => (dispatch: Dispatch) => Promise<void>;
   url: string;
   tournamentPhase: PhaseEntity;
   onMoveDown: (event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => void;
@@ -81,7 +82,7 @@ const PhaseCard: React.FC<{
 };
 
 interface PhaseListProps {
-  deletePhase: any;
+  deletePhase: (phase: PhaseEntity) => (dispatch: Dispatch) => Promise<void>;
   onMoveDown: (
     index: number
   ) => (event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => void;

--- a/src/Phases/actions.ts
+++ b/src/Phases/actions.ts
@@ -32,7 +32,9 @@ export const deletePhaseSuccess = (
   payload
 });
 
-export const deletePhaseFailure = (payload: any): HttpAction<ActionTypes> => ({
+export const deletePhaseFailure = (
+  payload: unknown
+): HttpAction<ActionTypes> => ({
   type: DELETE_PHASE_FAILURE,
   payload
 });
@@ -55,7 +57,9 @@ export const batchPatchPhaseSuccess = (
   payload: payload
 });
 
-export const patchPhaseFailure = (payload: any): HttpAction<ActionTypes> => ({
+export const patchPhaseFailure = (
+  payload: unknown
+): HttpAction<ActionTypes> => ({
   type: PATCH_PHASE_FAILURE,
   payload
 });
@@ -71,7 +75,9 @@ export const postPhaseSuccess = (
   payload
 });
 
-export const postPhaseFailure = (payload: any): HttpAction<ActionTypes> => ({
+export const postPhaseFailure = (
+  payload: unknown
+): HttpAction<ActionTypes> => ({
   type: POST_PHASE_FAILURE,
   payload
 });
@@ -87,7 +93,7 @@ export const getPhaseSuccess = (
   payload
 });
 
-export const getPhaseFailure = (payload: any): HttpAction<ActionTypes> => ({
+export const getPhaseFailure = (payload: unknown): HttpAction<ActionTypes> => ({
   type: GET_PHASE_FAILURE,
   payload
 });

--- a/src/PlayerStatsLog/actions.ts
+++ b/src/PlayerStatsLog/actions.ts
@@ -35,7 +35,7 @@ export const deletePlayerStatsLogSuccess = (
 });
 
 export const deletePlayerStatsLogFailure = (
-  payload: any
+  payload: unknown
 ): HttpAction<ActionTypes> => ({
   type: DELETE_PLAYER_STATS_LOG_FAILURE,
   payload
@@ -53,7 +53,7 @@ export const getPlayerStatsLogsByFilterSuccess = (
 });
 
 export const getPlayerStatsLogsByFilterFailure = (
-  payload: any
+  payload: unknown
 ): HttpAction<ActionTypes> => ({
   type: GET_PLAYER_STATS_LOGS_BY_FILTER_FAILURE,
   payload
@@ -71,7 +71,7 @@ export const patchPlayerStatsLogsSuccess = (
 });
 
 export const patchPlayerStatsLogsFailure = (
-  payload: any
+  payload: unknown
 ): HttpAction<ActionTypes> => ({
   type: PATCH_PLAYER_STATS_LOG_FAILURE,
   payload
@@ -89,7 +89,7 @@ export const postPlayerStatsLogsSuccess = (
 });
 
 export const postPlayerStatsLogsFailure = (
-  payload: any
+  payload: unknown
 ): HttpAction<ActionTypes> => ({
   type: POST_PLAYER_STATS_LOG_FAILURE,
   payload

--- a/src/Players/actions.ts
+++ b/src/Players/actions.ts
@@ -23,7 +23,9 @@ export const deletePlayerSuccess = (
   payload
 });
 
-export const deletePlayerFailure = (payload: any): HttpAction<ActionTypes> => ({
+export const deletePlayerFailure = (
+  payload: unknown
+): HttpAction<ActionTypes> => ({
   type: DELETE_PLAYER_FAILURE,
   payload
 });
@@ -39,7 +41,9 @@ export const patchPlayerSuccess = (
   payload
 });
 
-export const patchPlayerFailure = (payload: any): HttpAction<ActionTypes> => ({
+export const patchPlayerFailure = (
+  payload: unknown
+): HttpAction<ActionTypes> => ({
   type: PATCH_PLAYER_FAILURE,
   payload
 });
@@ -55,7 +59,9 @@ export const postPlayerSuccess = (
   payload
 });
 
-export const postPlayerFailure = (payload: any): HttpAction<ActionTypes> => ({
+export const postPlayerFailure = (
+  payload: unknown
+): HttpAction<ActionTypes> => ({
   type: POST_PLAYER_FAILURE,
   payload
 });

--- a/src/Registrations/TeamRosterInviteResponseForm.tsx
+++ b/src/Registrations/TeamRosterInviteResponseForm.tsx
@@ -22,6 +22,7 @@ import { ApiCustomFieldType } from '../Shared/httpClient/apiTypes';
 import ConsentInput from '../Shared/UI/Form/ConsentInput';
 
 const FIELD_COMPONENTS: {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- registry of field components with incompatible prop shapes (StringInput, DateInput, ConsentInput, Datetime)
   [key in ApiCustomFieldType]: React.ComponentType<any>;
 } = {
   consent: ConsentInput,
@@ -66,6 +67,7 @@ export function CustomField({ field }: CustomFieldProps) {
         <Field
           name={`response.${field.id}`}
           className="has-text-centered"
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any -- render prop value type varies per field component in FIELD_COMPONENTS
           render={(props: FieldRenderProps<any, any>) => {
             const customProps = {
               ...fieldProps(field),

--- a/src/Registrations/actions.ts
+++ b/src/Registrations/actions.ts
@@ -49,7 +49,7 @@ export const deleteRegistrationSuccess = (
 });
 
 export const deleteRegistrationFailure = (
-  payload: any
+  payload: unknown
 ): HttpAction<ActionTypes> => ({
   type: DELETE_REGISTRATION_FAILURE,
   payload
@@ -67,7 +67,7 @@ export const getRegistrationSuccess = (
 });
 
 export const getRegistrationFailure = (
-  payload: any
+  payload: unknown
 ): HttpAction<ActionTypes> => ({
   type: GET_REGISTRATION_FAILURE,
   payload
@@ -85,7 +85,7 @@ export const getRegistrationInviteSuccess = (
 });
 
 export const getRegistrationInviteFailure = (
-  payload: any
+  payload: unknown
 ): HttpAction<ActionTypes> => ({
   type: GET_REGISTRATION_INVITE_FAILURE,
   payload
@@ -103,7 +103,7 @@ export const patchRegistrationSuccess = (
 });
 
 export const patchRegistrationFailure = (
-  payload: any
+  payload: unknown
 ): HttpAction<ActionTypes> => ({
   type: PATCH_REGISTRATION_FAILURE,
   payload
@@ -121,7 +121,7 @@ export const putRegistrationGenerateInvitesSuccess = (
 });
 
 export const putRegistrationGenerateInvitesFailure = (
-  payload: any
+  payload: unknown
 ): HttpAction<ActionTypes> => ({
   type: PUT_REGISTRATION_GENERATE_INVITES_FAILURE,
   payload
@@ -146,7 +146,7 @@ export const putRegistrationResponseApproveSuccess = (payload: {
 });
 
 export const putRegistrationResponseApproveFailure = (
-  payload: any
+  payload: unknown
 ): HttpAction<ActionTypes> => ({
   type: PUT_REGISTRATION_RESPONSE_APPROVE_FAILURE,
   payload
@@ -164,7 +164,7 @@ export const postRegistrationSuccess = (
 });
 
 export const postRegistrationFailure = (
-  payload: any
+  payload: unknown
 ): HttpAction<ActionTypes> => ({
   type: POST_REGISTRATION_FAILURE,
   payload

--- a/src/ScoreboardSettings/actions.ts
+++ b/src/ScoreboardSettings/actions.ts
@@ -30,7 +30,7 @@ export const deleteScoreboardSettingSuccess = (
 });
 
 export const deleteScoreboardSettingFailure = (
-  payload: any
+  payload: unknown
 ): HttpAction<ActionTypes> => ({
   type: DELETE_SCOREBOARD_SETTING_FAILURE,
   payload
@@ -48,7 +48,7 @@ export const patchScoreboardSettingSuccess = (
 });
 
 export const patchScoreboardSettingFailure = (
-  payload: any
+  payload: unknown
 ): HttpAction<ActionTypes> => ({
   type: PATCH_SCOREBOARD_SETTING_FAILURE,
   payload
@@ -66,7 +66,7 @@ export const postScoreboardSettingSuccess = (
 });
 
 export const postScoreboardSettingFailure = (
-  payload: any
+  payload: unknown
 ): HttpAction<ActionTypes> => ({
   type: POST_SCOREBOARD_SETTING_FAILURE,
   payload

--- a/src/Shared/UI/Form/Datetime.tsx
+++ b/src/Shared/UI/Form/Datetime.tsx
@@ -20,6 +20,7 @@ class Datetime extends React.Component<FieldRenderProps<string, HTMLElement>> {
     );
   }
 
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- react-datetime ships no types (see react-datetime.d.ts ambient declaration)
   renderInput(props: any, openCalendar: any, closeCalendar: any) {
     const clear = () => {
       props.onChange({ target: { value: '' } });

--- a/src/Shared/UI/Form/FileUpload.tsx
+++ b/src/Shared/UI/Form/FileUpload.tsx
@@ -28,7 +28,7 @@ function FileUpload({
   );
   const { t } = useTranslation();
 
-  const onDrop = async (acceptedFiles: any) => {
+  const onDrop = async (acceptedFiles: File[]) => {
     const file = acceptedFiles[0];
     if (!file) return;
 
@@ -52,13 +52,12 @@ function FileUpload({
         onError: () => setError(t('uploadError'))
       });
     } catch (err) {
-      if (
-        err &&
-        (err as any).response &&
-        (err as any).response.data &&
-        (err as any).response.data.error
-      ) {
-        setError((err as any).response.data.error);
+      const uploadError = err as {
+        response?: { data?: { error?: string } };
+      };
+
+      if (uploadError?.response?.data?.error) {
+        setError(uploadError.response.data.error);
       } else {
         setError(t('uploadError'));
       }

--- a/src/Shared/UI/Form/MetaInput.tsx
+++ b/src/Shared/UI/Form/MetaInput.tsx
@@ -4,17 +4,13 @@ import { FieldMetaState } from 'react-final-form';
 import './MetaInput.scss';
 import { isArray } from 'util';
 
-interface MetaInputProps {
+interface MetaInputProps<T> {
   className?: string;
   component: (inputMetaClasses: string) => ReactNode;
-  meta: FieldMetaState<string>;
+  meta: FieldMetaState<T>;
 }
 
-const MetaInput: React.FC<MetaInputProps> = ({
-  className,
-  component,
-  meta
-}) => {
+const MetaInput = <T,>({ className, component, meta }: MetaInputProps<T>) => {
   const shouldSetError =
     meta.touched && !meta.dirtySinceLastSubmit && meta.invalid;
 

--- a/src/Shared/UI/Form/Select.tsx
+++ b/src/Shared/UI/Form/Select.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { FieldRenderProps } from 'react-final-form';
 import { default as ReactSelect } from 'react-select';
 import { ValueType } from 'react-select/lib/types';
+import { StylesConfig } from 'react-select/lib/styles';
 import { useTheme } from '../../../Theme/useTheme';
 import './Select.scss';
 
@@ -40,8 +41,8 @@ const SelectInput: React.FC<SelectInputProps> = ({
   const value = findOptionByValue(options, input.value);
 
   // Create styles object using theme colors
-  const selectStyles = {
-    menu: (provided: any) => ({
+  const selectStyles: StylesConfig = {
+    menu: provided => ({
       ...provided,
       backgroundColor: theme.colors.background,
       border: 'none',
@@ -52,11 +53,11 @@ const SelectInput: React.FC<SelectInputProps> = ({
       zIndex: 9999,
       position: 'absolute'
     }),
-    menuPortal: (provided: any) => ({
+    menuPortal: provided => ({
       ...provided,
       zIndex: 9999
     }),
-    option: (provided: any, state: any) => ({
+    option: (provided, state) => ({
       ...provided,
       backgroundColor: state.isSelected
         ? theme.colors.primary
@@ -69,15 +70,15 @@ const SelectInput: React.FC<SelectInputProps> = ({
         backgroundColor: theme.colors.primary
       }
     }),
-    singleValue: (provided: any) => ({
+    singleValue: provided => ({
       ...provided,
       color: theme.colors.text
     }),
-    placeholder: (provided: any) => ({
+    placeholder: provided => ({
       ...provided,
       color: theme.colors.textPlaceholder
     }),
-    dropdownIndicator: (provided: any, state: any) => ({
+    dropdownIndicator: (provided, state) => ({
       ...provided,
       color: state.isFocused
         ? theme.colors.primary
@@ -86,7 +87,7 @@ const SelectInput: React.FC<SelectInputProps> = ({
         color: theme.colors.primary
       }
     }),
-    clearIndicator: (provided: any, state: any) => ({
+    clearIndicator: (provided, state) => ({
       ...provided,
       color: state.isFocused
         ? theme.colors.primary

--- a/src/Shared/UI/Form/StandaloneSelect.tsx
+++ b/src/Shared/UI/Form/StandaloneSelect.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { default as ReactSelect } from 'react-select';
 import { ValueType } from 'react-select/lib/types';
+import { StylesConfig } from 'react-select/lib/styles';
 import { useTheme } from '../../../Theme/useTheme';
 
 export interface SelectOptionType {
@@ -41,8 +42,8 @@ const StandaloneSelect: React.FC<StandaloneSelectProps> = ({
   const selectedOption = value ? findOptionByValue(options, value) : undefined;
 
   // Create styles object using theme colors
-  const selectStyles = {
-    control: (provided: any, state: any) => ({
+  const selectStyles: StylesConfig = {
+    control: (provided, state) => ({
       ...provided,
       backgroundColor: theme.colors.background,
       borderColor: state.isFocused ? theme.colors.primary : theme.colors.border,
@@ -62,7 +63,7 @@ const StandaloneSelect: React.FC<StandaloneSelectProps> = ({
         borderColor: state.isFocused ? theme.colors.primary : theme.colors.text
       }
     }),
-    menu: (provided: any) => ({
+    menu: provided => ({
       ...provided,
       backgroundColor: theme.colors.background,
       border: `2px solid ${theme.colors.border}`,
@@ -77,11 +78,11 @@ const StandaloneSelect: React.FC<StandaloneSelectProps> = ({
         minWidth: '280px'
       }
     }),
-    menuPortal: (provided: any) => ({
+    menuPortal: provided => ({
       ...provided,
       zIndex: 9999
     }),
-    option: (provided: any, state: any) => ({
+    option: (provided, state) => ({
       ...provided,
       backgroundColor: state.isSelected
         ? theme.colors.primary
@@ -95,15 +96,15 @@ const StandaloneSelect: React.FC<StandaloneSelectProps> = ({
         backgroundColor: theme.colors.primary
       }
     }),
-    singleValue: (provided: any) => ({
+    singleValue: provided => ({
       ...provided,
       color: theme.colors.text
     }),
-    placeholder: (provided: any) => ({
+    placeholder: provided => ({
       ...provided,
       color: theme.colors.textPlaceholder
     }),
-    dropdownIndicator: (provided: any, state: any) => ({
+    dropdownIndicator: (provided, state) => ({
       ...provided,
       color: state.isFocused
         ? theme.colors.primary
@@ -112,7 +113,7 @@ const StandaloneSelect: React.FC<StandaloneSelectProps> = ({
         color: theme.colors.primary
       }
     }),
-    clearIndicator: (provided: any, state: any) => ({
+    clearIndicator: (provided, state) => ({
       ...provided,
       color: state.isFocused
         ? theme.colors.primary

--- a/src/Shared/UI/Form/TimeInput.tsx
+++ b/src/Shared/UI/Form/TimeInput.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { FieldMetaState, FieldRenderProps } from 'react-final-form';
+import { FieldRenderProps } from 'react-final-form';
 import MetaInput from './MetaInput';
 
 interface TimeInputProps extends FieldRenderProps<number, HTMLInputElement> {
@@ -75,7 +75,7 @@ const TimeInput: React.FunctionComponent<TimeInputProps> = ({
           disabled={disabled}
         />
       )}
-      meta={(meta as unknown) as FieldMetaState<string>}
+      meta={meta}
     />
   );
 };

--- a/src/Shared/UI/Form/TimeInput.tsx
+++ b/src/Shared/UI/Form/TimeInput.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { FieldRenderProps } from 'react-final-form';
+import { FieldMetaState, FieldRenderProps } from 'react-final-form';
 import MetaInput from './MetaInput';
 
 interface TimeInputProps extends FieldRenderProps<number, HTMLInputElement> {
@@ -75,7 +75,7 @@ const TimeInput: React.FunctionComponent<TimeInputProps> = ({
           disabled={disabled}
         />
       )}
-      meta={meta as any}
+      meta={(meta as unknown) as FieldMetaState<string>}
     />
   );
 };

--- a/src/Shared/UI/Form/Validators/commonValidators.test.ts
+++ b/src/Shared/UI/Form/Validators/commonValidators.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-explicit-any -- deliberately calling string validators with null/undefined to test defensive handling */
 import {
   mustHaveAtLeastTwoWords,
   required,

--- a/src/Shared/UI/Form/Validators/commonValidators.ts
+++ b/src/Shared/UI/Form/Validators/commonValidators.ts
@@ -11,16 +11,16 @@ const STRONG_PASSWORD_REGEX = RegExp(
 const USERNAME_REGEX = RegExp(/^([A-Za-z0-9]+(?:.-[a-z0-9]+)*){4,20}$/);
 const PIN_REGEX = RegExp(/^\d{4,}$/);
 
-export type ValidatorFunction = (value: any) => string | undefined;
+export type ValidatorFunction = (value: string) => string | undefined;
 export type AsyncValidatorFunction = (
-  value: any
+  value: string
 ) => Promise<string | undefined>;
 
 export const required = (value: string) =>
   value ? undefined : "Can't be blank";
 
-export const mustBeNumber = (value: any) =>
-  isNaN(value) ? 'Must be a number' : undefined;
+export const mustBeNumber = (value: string | number) =>
+  isNaN(Number(value)) ? 'Must be a number' : undefined;
 
 export const minValue = (min: number) => (value: number) =>
   isNaN(value) || value >= min ? undefined : `Should be greater than ${min}`;
@@ -85,7 +85,7 @@ export const mustHaveAtLeastTwoWords = (value: string) => {
 export const composeValidators = (
   validators: ValidatorFunction[],
   asyncValidators: AsyncValidatorFunction[] = []
-) => async (value: any) => {
+) => async (value: string) => {
   const syncErrors = validators.reduce(
     (errors: string[] | undefined, validator: ValidatorFunction) => {
       const validatorError = validator(value);

--- a/src/Shared/UI/NavTopToolbar.tsx
+++ b/src/Shared/UI/NavTopToolbar.tsx
@@ -107,8 +107,11 @@ class NavTopToolbar extends React.Component<NavTopToolbarProps> {
     );
   }
 
-  close = (event: any) => {
-    if (event && !event.target.classList.contains('navbar-burger')) {
+  close = (event?: globalThis.MouseEvent) => {
+    if (
+      event &&
+      !(event.target as HTMLElement).classList.contains('navbar-burger')
+    ) {
       const menu = document.getElementById('menu');
       menu!.classList.remove('is-active');
 

--- a/src/Shared/UI/NavTopToolbar.tsx
+++ b/src/Shared/UI/NavTopToolbar.tsx
@@ -110,7 +110,8 @@ class NavTopToolbar extends React.Component<NavTopToolbarProps> {
   close = (event?: globalThis.MouseEvent) => {
     if (
       event &&
-      !(event.target as HTMLElement).classList.contains('navbar-burger')
+      event.target instanceof HTMLElement &&
+      !event.target.classList.contains('navbar-burger')
     ) {
       const menu = document.getElementById('menu');
       menu!.classList.remove('is-active');

--- a/src/Shared/UI/PWAInstallPrompt.tsx
+++ b/src/Shared/UI/PWAInstallPrompt.tsx
@@ -13,6 +13,10 @@ interface BeforeInstallPromptEvent extends Event {
   prompt(): Promise<void>;
 }
 
+interface NavigatorWithStandalone extends Navigator {
+  standalone?: boolean;
+}
+
 declare global {
   interface WindowEventMap {
     beforeinstallprompt: BeforeInstallPromptEvent;
@@ -32,7 +36,8 @@ const PWAInstallPrompt: React.FC = () => {
     const checkIfInstalled = () => {
       const isStandalone = window.matchMedia('(display-mode: standalone)')
         .matches;
-      const isWebview = (window.navigator as any).standalone === true;
+      const isWebview =
+        (window.navigator as NavigatorWithStandalone).standalone === true;
 
       return isStandalone || isWebview;
     };
@@ -71,7 +76,8 @@ const PWAInstallPrompt: React.FC = () => {
     const timer = setTimeout(() => {
       if (!isInstalled && !deferredPrompt) {
         const isIOS = /iPad|iPhone|iPod/.test(navigator.userAgent);
-        const isInStandaloneMode = (window.navigator as any).standalone;
+        const isInStandaloneMode = (window.navigator as NavigatorWithStandalone)
+          .standalone;
 
         if (isIOS && !isInStandaloneMode) {
           setShowInstallPrompt(true);

--- a/src/Shared/analytics/analytics.ts
+++ b/src/Shared/analytics/analytics.ts
@@ -18,7 +18,10 @@ const bootstrap = () => {
   }
 };
 
-const track = (eventName: string, eventProperties?: Record<string, any>) => {
+const track = (
+  eventName: string,
+  eventProperties?: Record<string, unknown>
+) => {
   if (REACT_APP_ENV === 'prod') {
     amplitude.track(eventName, eventProperties);
   } else {

--- a/src/Shared/countryCodeUtils.test.ts
+++ b/src/Shared/countryCodeUtils.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-explicit-any -- reassigning read-only globals (navigator, Intl) for test mocking */
 import { getCountryCodeFromBrowser } from './countryCodeUtils';
 
 describe('getCountryCodeFromBrowser', () => {

--- a/src/Shared/hooks/useFilteredItemsByDate.ts
+++ b/src/Shared/hooks/useFilteredItemsByDate.ts
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 import { useLocation, useHistory } from 'react-router-dom';
 
-const useFilteredItemsByDate = <T extends { [key: string]: any }>(
+const useFilteredItemsByDate = <T extends object>(
   items: T[],
   propertyName: string
 ) => {
@@ -19,8 +19,9 @@ const useFilteredItemsByDate = <T extends { [key: string]: any }>(
 
   const filteredItems = filterValue
     ? stateItems.filter((item: T) => {
-        return item.hasOwnProperty(propertyName)
-          ? item[propertyName]
+        const record = (item as unknown) as Record<string, string>;
+        return record.hasOwnProperty(propertyName)
+          ? record[propertyName]
               .toLocaleLowerCase()
               .indexOf(filterValue.toLocaleLowerCase()) >= 0
           : true;

--- a/src/Shared/hooks/useFilteredItemsByDate.ts
+++ b/src/Shared/hooks/useFilteredItemsByDate.ts
@@ -19,9 +19,9 @@ const useFilteredItemsByDate = <T extends object>(
 
   const filteredItems = filterValue
     ? stateItems.filter((item: T) => {
-        const record = (item as unknown) as Record<string, string>;
+        const record = (item as unknown) as Record<string, unknown>;
         return record.hasOwnProperty(propertyName)
-          ? record[propertyName]
+          ? String(record[propertyName])
               .toLocaleLowerCase()
               .indexOf(filterValue.toLocaleLowerCase()) >= 0
           : true;

--- a/src/Shared/hooks/useFilteredItemsByString.ts
+++ b/src/Shared/hooks/useFilteredItemsByString.ts
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 import { useLocation, useHistory } from 'react-router-dom';
 
-const useFilteredItemsByString = <T extends { [key: string]: any }>(
+const useFilteredItemsByString = <T extends object>(
   items: T[],
   propertyName: string
 ) => {
@@ -19,8 +19,9 @@ const useFilteredItemsByString = <T extends { [key: string]: any }>(
 
   const filteredItems = searchValue
     ? stateItems.filter((item: T) => {
-        return item.hasOwnProperty(propertyName)
-          ? item[propertyName]
+        const record = (item as unknown) as Record<string, string>;
+        return record.hasOwnProperty(propertyName)
+          ? record[propertyName]
               .toLocaleLowerCase()
               .indexOf(searchValue.toLocaleLowerCase()) >= 0
           : true;

--- a/src/Shared/hooks/useFilteredItemsByString.ts
+++ b/src/Shared/hooks/useFilteredItemsByString.ts
@@ -19,9 +19,9 @@ const useFilteredItemsByString = <T extends object>(
 
   const filteredItems = searchValue
     ? stateItems.filter((item: T) => {
-        const record = (item as unknown) as Record<string, string>;
+        const record = (item as unknown) as Record<string, unknown>;
         return record.hasOwnProperty(propertyName)
-          ? record[propertyName]
+          ? String(record[propertyName])
               .toLocaleLowerCase()
               .indexOf(searchValue.toLocaleLowerCase()) >= 0
           : true;

--- a/src/Shared/httpClient/ApiError.ts
+++ b/src/Shared/httpClient/ApiError.ts
@@ -1,5 +1,6 @@
 export interface ApiDataError {
   status: number;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- API error body shape varies per endpoint (errors.base, errors.response, field-keyed errors, ...)
   data: any;
 }
 

--- a/src/Shared/httpClient/apiTypes.ts
+++ b/src/Shared/httpClient/apiTypes.ts
@@ -974,7 +974,7 @@ export interface ApiBillingAgreement {
     active: boolean;
     description: string;
     name: string;
-    sport: any;
+    sport: { id: string } | null;
     sport_id: string;
   };
   plan_id: string;

--- a/src/Shared/httpClient/publicHttpClient.test.ts
+++ b/src/Shared/httpClient/publicHttpClient.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-explicit-any -- mocking the read-only global fetch for tests */
 import publicHttpClient from './publicHttpClient';
 
 // Mock environment variable

--- a/src/Shared/httpClient/requestFilter.ts
+++ b/src/Shared/httpClient/requestFilter.ts
@@ -6,7 +6,7 @@ export interface OrCondition {
   [key: string]: string;
 }
 
-export interface ExtendedRequestFilter extends Record<string, any> {
+export interface ExtendedRequestFilter extends Record<string, unknown> {
   or?: OrCondition[];
 }
 

--- a/src/Shared/httpClient/scoreboardApiTypes.ts
+++ b/src/Shared/httpClient/scoreboardApiTypes.ts
@@ -32,7 +32,7 @@ interface ApiPlayerStatsValues {
   turnovers: number;
 }
 
-interface ApiPlayer {
+export interface ApiPlayer {
   id: string;
   name: string;
   number: string | null;
@@ -44,8 +44,8 @@ export interface ApiTeam {
   logo_url: string;
   name: string;
   players: ApiPlayer[];
-  stats_values: Record<string, any>;
-  total_player_stats: Record<string, any>;
+  stats_values: Record<string, number>;
+  total_player_stats: Record<string, number>;
   tri_code: string;
 }
 

--- a/src/Shared/store/helpers.ts
+++ b/src/Shared/store/helpers.ts
@@ -1,8 +1,11 @@
 export const mapStringOrDefault = (value: string | undefined) =>
   value ? value : '';
 
-export const returnProperty = (key: string) => <T>(entity: T): string =>
-  String(((entity as unknown) as Record<string, unknown>)[key]);
+export const returnProperty = <K extends string>(key: K) => <
+  T extends Record<K, unknown>
+>(
+  entity: T
+): string => String(entity[key]);
 
 export const apiDataToEntitiesOverride = <T, E>(
   mapFunc: (apiData: T) => E,

--- a/src/Shared/store/helpers.ts
+++ b/src/Shared/store/helpers.ts
@@ -1,9 +1,8 @@
 export const mapStringOrDefault = (value: string | undefined) =>
   value ? value : '';
 
-export const returnProperty = (key: string) => (entity: {
-  [key: string]: any;
-}) => entity[key];
+export const returnProperty = (key: string) => <T>(entity: T): string =>
+  String(((entity as unknown) as Record<string, unknown>)[key]);
 
 export const apiDataToEntitiesOverride = <T, E>(
   mapFunc: (apiData: T) => E,
@@ -67,16 +66,19 @@ export const mapEntitiesByKey = <T>(currentEntitiesMap: {
   };
 };
 
-export const entityById = (
-  currentEntitiesMap: { [key: string]: any },
+export const entityById = <T extends { id: string }>(
+  currentEntitiesMap: { [key: string]: T },
   id: string
 ) => (key: string) => {
   return currentEntitiesMap[key].id !== id;
 };
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- dynamic action.type -> handler dispatch table; each reducer.ts supplies handlers with its own distinct state/action types
 export const createReducer = <T = any>(
   initialState: T,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- see above
   handlers: { [key: string]: any }
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- see above
 ) => (state: T = initialState, action: any): T => {
   if (handlers.hasOwnProperty(action.type)) {
     return handlers[action.type](state, action);

--- a/src/Shared/store/interfaces.ts
+++ b/src/Shared/store/interfaces.ts
@@ -1,4 +1,4 @@
-export interface HttpAction<T, P = any> {
+export interface HttpAction<T, P = unknown> {
   type: T;
   payload?: P;
 }

--- a/src/Sports/actions.ts
+++ b/src/Sports/actions.ts
@@ -19,7 +19,7 @@ export const getSportSuccess = (
   payload
 });
 
-export const getSportFailure = (payload: any): HttpAction<ActionTypes> => ({
+export const getSportFailure = (payload: unknown): HttpAction<ActionTypes> => ({
   type: GET_SPORT_FAILURE,
   payload
 });
@@ -35,7 +35,9 @@ export const getSportsSuccess = (
   payload
 });
 
-export const getSportsFailure = (payload: any): HttpAction<ActionTypes> => ({
+export const getSportsFailure = (
+  payload: unknown
+): HttpAction<ActionTypes> => ({
   type: GET_SPORTS_FAILURE,
   payload
 });

--- a/src/TeamStatsLog/actions.ts
+++ b/src/TeamStatsLog/actions.ts
@@ -20,7 +20,7 @@ export const getTeamStatsLogsByFilterSuccess = (
 });
 
 export const getTeamStatsLogsByFilterFailure = (
-  payload: any
+  payload: unknown
 ): HttpAction<ActionTypes> => ({
   type: GET_TEAM_STATS_LOGS_BY_FILTER_FAILURE,
   payload

--- a/src/Teams/actions.ts
+++ b/src/Teams/actions.ts
@@ -23,7 +23,9 @@ export const deleteTeamSuccess = (
   payload
 });
 
-export const deleteTeamFailure = (payload: any): HttpAction<ActionTypes> => ({
+export const deleteTeamFailure = (
+  payload: unknown
+): HttpAction<ActionTypes> => ({
   type: DELETE_TEAM_FAILURE,
   payload
 });
@@ -39,7 +41,9 @@ export const patchTeamSuccess = (
   payload
 });
 
-export const patchTeamFailure = (payload: any): HttpAction<ActionTypes> => ({
+export const patchTeamFailure = (
+  payload: unknown
+): HttpAction<ActionTypes> => ({
   type: PATCH_TEAM_FAILURE,
   payload
 });
@@ -55,7 +59,7 @@ export const postTeamSuccess = (
   payload
 });
 
-export const postTeamFailure = (payload: any): HttpAction<ActionTypes> => ({
+export const postTeamFailure = (payload: unknown): HttpAction<ActionTypes> => ({
   type: POST_TEAM_FAILURE,
   payload
 });

--- a/src/Theme/reducer.test.ts
+++ b/src/Theme/reducer.test.ts
@@ -81,7 +81,7 @@ describe('themeReducer', () => {
   describe('unknown action', () => {
     it('returns the original state unchanged', () => {
       const unknownAction = { type: 'UNKNOWN_ACTION', payload: 'test' };
-      const newState = themeReducer(initialState, unknownAction as any);
+      const newState = themeReducer(initialState, unknownAction);
 
       expect(newState).toBe(initialState);
     });

--- a/src/Theme/selectors.test.ts
+++ b/src/Theme/selectors.test.ts
@@ -51,6 +51,7 @@ describe('Theme Selectors', () => {
         otherModule: {
           someData: 'test'
         }
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any -- deliberately widening beyond StoreState to test unrelated extra state keys are ignored
       } as any;
 
       const result = currentTheme(state);
@@ -106,6 +107,7 @@ describe('Theme Selectors', () => {
         otherModule: {
           someData: 'test'
         }
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any -- deliberately widening beyond StoreState to test unrelated extra state keys are ignored
       } as any;
 
       const result = isThemeLoading(state);

--- a/src/Tournaments/actions.ts
+++ b/src/Tournaments/actions.ts
@@ -33,8 +33,8 @@ export const deleteTournamentStart = (): HttpAction<ActionTypes> => ({
 });
 
 export const deleteTournamentSuccess = (
-  payload: unknown
-): HttpAction<ActionTypes> => ({
+  payload: string
+): HttpAction<ActionTypes, string> => ({
   type: DELETE_TOURNAMENT_SUCCESS,
   payload
 });

--- a/src/Tournaments/actions.ts
+++ b/src/Tournaments/actions.ts
@@ -33,14 +33,14 @@ export const deleteTournamentStart = (): HttpAction<ActionTypes> => ({
 });
 
 export const deleteTournamentSuccess = (
-  payload: any
+  payload: unknown
 ): HttpAction<ActionTypes> => ({
   type: DELETE_TOURNAMENT_SUCCESS,
   payload
 });
 
 export const deleteTournamentFailure = (
-  payload: any
+  payload: unknown
 ): HttpAction<ActionTypes> => ({
   type: DELETE_TOURNAMENT_FAILURE,
   payload
@@ -58,7 +58,7 @@ export const patchTournamentSuccess = (
 });
 
 export const patchTournamentFailure = (
-  payload: any
+  payload: unknown
 ): HttpAction<ActionTypes> => ({
   type: PATCH_TOURNAMENT_FAILURE,
   payload
@@ -76,7 +76,7 @@ export const postTournamentSuccess = (
 });
 
 export const postTournamentFailure = (
-  payload: any
+  payload: unknown
 ): HttpAction<ActionTypes> => ({
   type: POST_TOURNAMENT_FAILURE,
   payload
@@ -94,7 +94,7 @@ export const getTournamentsByFilterSuccess = (
 });
 
 export const getTournamentsByFilterFailure = (
-  payload: any
+  payload: unknown
 ): HttpAction<ActionTypes> => ({
   type: GET_TOURNAMENTS_BY_FILTER_FAILURE,
   payload
@@ -112,7 +112,7 @@ export const getTournamentSuccess = (
 });
 
 export const getTournamentFailure = (
-  payload: any
+  payload: unknown
 ): HttpAction<ActionTypes> => ({
   type: GET_TOURNAMENT_FAILURE,
   payload
@@ -130,7 +130,7 @@ export const getBillingAgreementSuccess = (
 });
 
 export const getBillingAgreementFailure = (
-  payload: any
+  payload: unknown
 ): HttpAction<ActionTypes> => ({
   type: GET_BILLING_AGREEMENT_FAILURE,
   payload

--- a/src/Tournaments/dataMappers.ts
+++ b/src/Tournaments/dataMappers.ts
@@ -89,13 +89,15 @@ export const mapApiTeamStatToTeamStatEntity = (
   source: apiTeamStat.source
 });
 
-export const mapApiPlanToPlanEntity = (apiPlan: ApiPlan): PlanEntity => ({
+export const mapApiPlanToPlanEntity = (
+  apiPlan: ApiPlan & Partial<Omit<ApiBillingAgreement['plan'], keyof ApiPlan>>
+): PlanEntity => ({
   slug: apiPlan.slug,
   amount: apiPlan.amount,
-  active: (apiPlan as any).active || false,
-  description: (apiPlan as any).description || '',
-  name: (apiPlan as any).name || '',
-  sportId: (apiPlan as any).sport_id || ''
+  active: apiPlan.active || false,
+  description: apiPlan.description || '',
+  name: apiPlan.name || '',
+  sportId: apiPlan.sport_id || ''
 });
 
 export const mapApiBillingAgreementToBillingAgreementEntity = (

--- a/src/Tournaments/reducer.test.ts
+++ b/src/Tournaments/reducer.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-explicit-any -- incomplete fixture objects for entity fields not relevant to these reducer assertions */
 import {
   deleteTournamentFailure,
   deleteTournamentStart,


### PR DESCRIPTION
## Summary
- Enables `@typescript-eslint/no-explicit-any` project-wide (`.eslintrc.json`).
- Fixes all ~179 pre-existing `any` occurrences across 61 files. Most came from `HttpAction<T, P = any>`'s generic default propagating into nearly every Redux `actions.ts` payload — switching the default to `unknown` and threading concrete/unknown payload types through resolved the bulk automatically.
- Remaining cases handled by:
  - Typing against real library/API types where available (react-select `StylesConfig`, `react-facebook-login` response types, scoreboard API player/team shapes, `ApiSport`).
  - Reworking generic-but-safe helpers (`returnProperty`, `entityById`, `useFilteredItemsBy*`) to avoid the any/index-signature mismatch instead of casting.
  - `eslint-disable` with an inline reason for genuinely dynamic cases: untyped libraries (`react-datetime`), heterogeneous dispatch tables (`createReducer`'s handler map), and deliberately malformed test fixtures/global mocks.
- Along the way, found and fixed a latent bug this surfaced: `PhaseNew.tsx`'s `DispatchProps` type omitted `getTournamentBySlug`, so the connected component's real required-props were wrong under `mergeProps` — previously masked by an explicit `connector<any>` cast at the export site.