### PR TITLE
chore: adjust dev env for turbo

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -20,6 +20,9 @@ RUN apt-get update && apt-get install -y \
     xfonts-scalable \
     && rm -rf /var/lib/apt/lists/*
 
+# Enable pnpm (matches packageManager pin in root package.json)
+RUN corepack enable && corepack prepare pnpm@9.15.0 --activate
+
 ENV APP_HOME /app
 RUN mkdir $APP_HOME
 WORKDIR $APP_HOME

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -14,14 +14,15 @@
 		"dbaeumer.vscode-eslint",
         "rvest.vs-code-prettier-eslint",
 		"GitHub.copilot",
-		"GitHub.copilot-chat"
+		"GitHub.copilot-chat",
+		"anthropic.claude-code"
 	],
 
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	"forwardPorts": [3000],
 
 	// Use 'postCreateCommand' to run commands after the container is created.
-	"postCreateCommand": "yarn install && /workspace/.devcontainer/setup-cypress.sh",
+	"postCreateCommand": "pnpm install && /workspace/.devcontainer/setup-cypress.sh",
 
 	// Use 'postStartCommand' to ensure services are running
 	"postStartCommand": "service dbus start > /dev/null 2>&1 && pkill Xvfb > /dev/null 2>&1; export DISPLAY=:99 && Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &",

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -9,6 +9,8 @@ services:
     volumes:
       - ..:/workspace:cached
       - node_modules:/workspace/node_modules
+      - cms-node_modules:/workspace/apps/cms/node_modules
+      - pnpm-store:/root/.local/share/pnpm/store
       - vscode-extension:/root/.vscode-server-insiders
 
     # Overrides default command so things don't shut down after the process ends.
@@ -22,4 +24,6 @@ services:
 
 volumes:
   node_modules:
+  cms-node_modules:
+  pnpm-store:
   vscode-extension:

--- a/.devcontainer/setup-cypress.sh
+++ b/.devcontainer/setup-cypress.sh
@@ -3,6 +3,8 @@
 # Cypress DevContainer Setup Script
 echo "Setting up Cypress for devcontainer..."
 
+CMS_DIR="/workspace/apps/cms"
+
 # Start D-Bus service (required for Cypress)
 echo "Starting D-Bus service..."
 service dbus start > /dev/null 2>&1
@@ -23,23 +25,23 @@ unset CYPRESS_CACHE_FOLDER
 
 # Install Cypress binary if not already installed
 echo "Ensuring Cypress binary is installed..."
-./node_modules/.bin/cypress install > /dev/null 2>&1
+"$CMS_DIR/node_modules/.bin/cypress" install > /dev/null 2>&1
 
 # Verify Cypress can run
 echo "Testing Cypress installation..."
-if DISPLAY=:99 ./node_modules/.bin/cypress verify > /dev/null 2>&1; then
+if DISPLAY=:99 "$CMS_DIR/node_modules/.bin/cypress" verify > /dev/null 2>&1; then
     echo "✅ Cypress is installed and working"
-else 
-    echo "❌ Cypress verification failed. Run 'yarn install' first."
+else
+    echo "❌ Cypress verification failed. Run 'pnpm install' first."
     exit 1
 fi
 
 echo "✅ Cypress devcontainer setup complete!"
 echo ""
-echo "Available commands:"
-echo "  yarn test:e2e:headless - Run Cypress tests (recommended)"  
-echo "  yarn test:e2e         - Run Cypress tests"
-echo "  yarn test:e2e:open    - Open Cypress Test Runner (if X11 forwarding available)"
+echo "Available commands (run from apps/cms, or via 'pnpm --filter @gochamps/cms <script>'):"
+echo "  test:e2e:headless - Run Cypress tests (recommended)"
+echo "  test:e2e          - Run Cypress tests"
+echo "  test:e2e:open     - Open Cypress Test Runner (if X11 forwarding available)"
 echo ""
 echo "Environment:"
 echo "  DISPLAY=$DISPLAY"

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 node_modules
 /.pnp
 .pnp.js
+.pnpm-store
 
 # testing
 coverage

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ This repository is a pnpm/Turborepo monorepo. Commands run from the repo root af
 
 Root-level (all apps, via Turborepo):
   * `pnpm build` - Build all apps for production
-  * `pnpm test` - Run the test suite for all apps
+  * `pnpm test:ci` - Run the test suite for all apps
   * `pnpm lint:check` - Check code linting for all apps
 
 CMS app (`apps/cms`):

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Go Champs is a comprehensive tournament management platform that serves as both 
 
 ### Prerequisites
 - Node.js (recommended version specified in `.nvmrc`)
-- Yarn package manager
+- pnpm package manager (`pnpm@9.15.0`, see `packageManager` in `package.json`)
 
 ### Local Development
 
@@ -32,17 +32,26 @@ This project includes a `.devcontainer` configuration for consistent development
 If you prefer to run locally outside a container:
 
 1. Clone the repository
-2. Install dependencies: `yarn`
-3. Start the development server: `yarn start`
-4. Run tests: `yarn test`
+2. Install dependencies: `pnpm install`
+3. Start the development server: `pnpm --filter @gochamps/cms start`
+4. Run tests: `pnpm test`
 
 ### Available Scripts
 
-After setup, you can run these commands:
-  * `yarn start` - Start the development server
-  * `yarn build` - Build the app for production
-  * `yarn test` - Run the test suite
-  * `yarn lint` - Run code linting
+This repository is a pnpm/Turborepo monorepo. Commands run from the repo root affect all apps (via Turborepo); use `--filter @gochamps/cms` to target the CMS app specifically, or `cd apps/cms` and drop the filter.
+
+Root-level (all apps, via Turborepo):
+  * `pnpm build` - Build all apps for production
+  * `pnpm test` - Run the test suite for all apps
+  * `pnpm lint:check` - Check code linting for all apps
+
+CMS app (`apps/cms`):
+  * `pnpm --filter @gochamps/cms start` - Start the development server
+  * `pnpm --filter @gochamps/cms build` - Build the app for production
+  * `pnpm --filter @gochamps/cms test` - Run the test suite
+  * `pnpm --filter @gochamps/cms test:e2e` - Run Cypress end-to-end tests
+  * `pnpm --filter @gochamps/cms lint` - Fix code linting
+  * `pnpm --filter @gochamps/cms lint:check` - Check code linting
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ If you prefer to run locally outside a container:
 
 1. Clone the repository
 2. Install dependencies: `pnpm install`
-3. Start the development server: `pnpm --filter @gochamps/cms start`
+3. Start the development server: `pnpm start`
 4. Run tests: `pnpm test`
 
 ### Available Scripts


### PR DESCRIPTION
## Summary

Wires local dev environment (devcontainer, Cypress setup script, README) to pnpm now that the repo runs on the pnpm/Turborepo monorepo scaffold (apps/cms). Follow-up on chore/pnpm-turborepo-scaffold.

## Changes

- .devcontainer/Dockerfile: enable Corepack, pin pnpm to 9.15.0 (matches packageManager in root package.json).
- .devcontainer/devcontainer.json: postCreateCommand switched from yarn install to pnpm install; added anthropic.claude-code extension.
- .devcontainer/docker-compose.yml: added cms-node_modules volume (mapped to apps/cms/node_modules) and pnpm-store volume for the pnpm content-addressable store.
- .devcontainer/setup-cypress.sh: Cypress binary path now resolved under apps/cms ($CMS_DIR) instead of repo root; updated echoed command hints to pnpm/--filter @gochamps/cms form.
- .gitignore: ignore .pnpm-store.
- README.md: prerequisites and setup steps updated to pnpm; "Available Scripts" section split into root-level Turborepo commands (pnpm build, pnpm test, pnpm lint:check) vs. CMS-app-specific commands (pnpm --filter @gochamps/cms <script>).

## Why

Local dev tooling (devcontainer, Cypress helper script, docs) still referenced yarn and repo-root paths from before the monorepo move; this brings them in line so a fresh devcontainer / local checkout works with pnpm and the apps/cms layout.

## Test plan

- [ ] Rebuild devcontainer, confirm pnpm install + setup-cypress.sh succeed and Cypress verifies.
- [ ] pnpm --filter @gochamps/cms test:e2e from repo root and from apps/cms both work.
- [ ] README commands run as documented.