### PR TITLE
feat: extract TeamEntity into @gochamps/domain-types as extraction pilot

### DIFF
--- a/apps/cms/package.json
+++ b/apps/cms/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "dependencies": {
     "@amplitude/analytics-browser": "^2.11.1",
+    "@gochamps/domain-types": "workspace:*",
     "@emailjs/browser": "^4.4.1",
     "@types/react-facebook-login": "^4.1.2",
     "animate.css": "^3.7.1",

--- a/apps/cms/package.json
+++ b/apps/cms/package.json
@@ -4,8 +4,8 @@
   "private": true,
   "dependencies": {
     "@amplitude/analytics-browser": "^2.11.1",
-    "@gochamps/domain-types": "workspace:*",
     "@emailjs/browser": "^4.4.1",
+    "@gochamps/domain-types": "workspace:*",
     "@types/react-facebook-login": "^4.1.2",
     "animate.css": "^3.7.1",
     "bulma": "^0.7.4",

--- a/apps/cms/src/Teams/state.ts
+++ b/apps/cms/src/Teams/state.ts
@@ -1,7 +1,3 @@
-// Value import, but only used in type position (extends below) — Babel's
-// per-file TS transform elides it at build time. Do not add a runtime
-// usage of these bindings here without first verifying the CRA/craco
-// build still resolves the workspace package (see PR discussion).
 import {
   CoachEntity as ImportedCoachEntity,
   TeamEntity as ImportedTeamEntity

--- a/apps/cms/src/Teams/state.ts
+++ b/apps/cms/src/Teams/state.ts
@@ -1,3 +1,7 @@
+// Value import, but only used in type position (extends below) — Babel's
+// per-file TS transform elides it at build time. Do not add a runtime
+// usage of these bindings here without first verifying the CRA/craco
+// build still resolves the workspace package (see PR discussion).
 import {
   CoachEntity as ImportedCoachEntity,
   TeamEntity as ImportedTeamEntity

--- a/apps/cms/src/Teams/state.ts
+++ b/apps/cms/src/Teams/state.ts
@@ -1,17 +1,10 @@
-export interface CoachEntity {
-  id: string;
-  name: string;
-  type: string;
-}
+import {
+  CoachEntity as ImportedCoachEntity,
+  TeamEntity as ImportedTeamEntity
+} from '@gochamps/domain-types';
 
-export interface TeamEntity {
-  id: string;
-  name: string;
-  logoUrl: string;
-  triCode: string;
-  primaryColor: string;
-  coaches: CoachEntity[];
-}
+export interface CoachEntity extends ImportedCoachEntity {}
+export interface TeamEntity extends ImportedTeamEntity {}
 
 export interface TeamState {
   isLoadingDeleteTeam: boolean;

--- a/packages/domain-types/package.json
+++ b/packages/domain-types/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "@gochamps/domain-types",
+  "version": "0.0.0",
+  "private": true,
+  "main": "src/index.ts",
+  "types": "src/index.ts"
+}

--- a/packages/domain-types/src/index.ts
+++ b/packages/domain-types/src/index.ts
@@ -1,0 +1,1 @@
+export * from './team';

--- a/packages/domain-types/src/team.ts
+++ b/packages/domain-types/src/team.ts
@@ -1,0 +1,14 @@
+export interface CoachEntity {
+  id: string;
+  name: string;
+  type: string;
+}
+
+export interface TeamEntity {
+  id: string;
+  name: string;
+  logoUrl: string;
+  triCode: string;
+  primaryColor: string;
+  coaches: CoachEntity[];
+}

--- a/packages/domain-types/tsconfig.json
+++ b/packages/domain-types/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "es2019",
+    "module": "esnext",
+    "moduleResolution": "node",
+    "strict": true,
+    "declaration": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true
+  },
+  "include": ["src"]
+}

--- a/packages/domain-types/tsconfig.json
+++ b/packages/domain-types/tsconfig.json
@@ -4,7 +4,6 @@
     "module": "esnext",
     "moduleResolution": "node",
     "strict": true,
-    "declaration": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
       '@emailjs/browser':
         specifier: ^4.4.1
         version: 4.4.1
+      '@gochamps/domain-types':
+        specifier: workspace:*
+        version: link:../../packages/domain-types
       '@types/react-facebook-login':
         specifier: ^4.1.2
         version: 4.1.11
@@ -249,6 +252,8 @@ importers:
       redux-devtools-extension:
         specifier: ^2.13.8
         version: 2.13.9(redux@4.2.1)
+
+  packages/domain-types: {}
 
 packages:
 


### PR DESCRIPTION
## Summary
- Task 5 of the Phase 0 modularization plan (`docs/superpowers/plans/2026-07-16-modularization-phase0-foundation.md`): proves the shared-package extraction pattern by moving `TeamEntity`/`CoachEntity` into a new workspace package `@gochamps/domain-types`.
- `apps/cms/src/Teams/state.ts` no longer declares these interfaces directly — it imports them from the package and re-declares via `extends {}` (the plan's literal bare re-export doesn't compile here: `isolatedModules` + internal usage of both types elsewhere in the file, and the repo's pinned prettier@1.19.1 rejects `export type {...} from`). All 28 existing consumers keep working unmodified.
- Verified: `tsc --noEmit` clean, `lint:check` clean, 789/789 tests passing, and a production `build:staging` succeeds.

## Process notes (for reviewers)
- Task-scoped review: approved, deviation independently verified.
- Final whole-branch review (opus): **Ready to merge — Yes**. Flagged follow-up-scope concerns for the *next* extraction phase (Game/Player/Tournament/Athlete), not blockers here:
  - The pilot only proves type-only imports work under CRA4/craco — a future package exporting a runtime value (const, enum, mapper) may hit webpack's `ModuleScopePlugin`/babel-loader scoping and needs a spike before that phase starts.
  - `packages/domain-types` has no CI/lint/typecheck coverage of its own yet (only picked up transitively via the cms app's build).
  - README/ARCHITECTURE.md don't yet document the new `packages/` tier; dependabot doesn't cover it.
- Two cheap Important findings (dependency alphabetical ordering, plan-doc deviation note) were fixed and re-reviewed clean in this branch.

## Test plan
- [x] `pnpm --filter @gochamps/cms exec tsc --noEmit` — exit 0
- [x] `pnpm --filter @gochamps/cms lint:check` — exit 0
- [x] `pnpm --filter @gochamps/cms test -- --watchAll=false` — 789/789 passing
- [x] `pnpm --filter @gochamps/cms build:staging` — succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)