### PR TITLE
Fix Cloudflare WAF blocking Cypress e2e API calls in CI

### DIFF
--- a/.github/workflows/master-ci.yml
+++ b/.github/workflows/master-ci.yml
@@ -127,6 +127,7 @@ jobs:
           TEST_USERNAME: ${{ secrets.TEST_USERNAME }}
           TEST_PASSWORD: ${{ secrets.TEST_PASSWORD }}
           CYPRESS_baseUrl: ${{ secrets.STAGING_APP_HOST }}
+          CYPRESS_E2E_TEST_KEY: ${{ secrets.E2E_TEST_KEY }}
           CYPRESS_defaultCommandTimeout: 15000
           CYPRESS_requestTimeout: 15000
           CYPRESS_responseTimeout: 15000
@@ -216,6 +217,7 @@ jobs:
           TEST_USERNAME: ${{ secrets.TEST_USERNAME }}
           TEST_PASSWORD: ${{ secrets.TEST_PASSWORD }}
           CYPRESS_baseUrl: ${{ secrets.PROD_APP_HOST }}
+          CYPRESS_E2E_TEST_KEY: ${{ secrets.E2E_TEST_KEY }}
           CYPRESS_defaultCommandTimeout: 15000
           CYPRESS_requestTimeout: 15000
           CYPRESS_responseTimeout: 15000

--- a/apps/cms/cypress/support/e2e.js
+++ b/apps/cms/cypress/support/e2e.js
@@ -27,5 +27,20 @@ beforeEach(() => {
   });
 });
 
+// Cloudflare's WAF rule on api.go-champs.com blocks non-GET requests unless
+// the Origin header matches an allowlist. Cypress's network layer doesn't
+// reliably reproduce that header on headless/CDP-driven requests, so every
+// API call gets blocked in CI even though the same flow works for real users.
+// This header is an allowlisted bypass configured on the Cloudflare rule.
+const E2E_TEST_KEY = Cypress.env('E2E_TEST_KEY');
+
+if (E2E_TEST_KEY) {
+  beforeEach(() => {
+    cy.intercept('**/v1/**', req => {
+      req.headers['x-e2e-test-key'] = E2E_TEST_KEY;
+    });
+  });
+}
+
 // Alternatively you can use CommonJS syntax:
 // require('./commands')


### PR DESCRIPTION
## Summary
- Prod Cypress e2e run was failing: Cloudflare custom rule on `api.go-champs.com` blocks non-GET requests unless `Origin` matches an allowlist (`go-champs.com`, `adm-go-champs.netlify.app`) and `Authorization` is present.
- Confirmed via Cloudflare Security Events log: block hit `POST /v1/accounts/signin`, correct `Referer`, `HeadlessChrome` user agent. Authorization is always sent by [httpClient.ts](apps/cms/src/Shared/httpClient/httpClient.ts) regardless of login state, so the `Origin` header is the condition failing — Cypress's network layer doesn't reliably reproduce it on headless/CDP-driven requests, even though the identical flow works for real user browsers.
- Cloudflare rule updated (out of repo) to add a bypass: `or http.request.headers["x-e2e-test-key"][0] eq "<secret>"`.
- This PR wires the matching header from the Cypress side:
  - [cypress/support/e2e.js](apps/cms/cypress/support/e2e.js): global `cy.intercept` on `**/v1/**` injects `x-e2e-test-key` from `Cypress.env('E2E_TEST_KEY')` when set.
  - [.github/workflows/master-ci.yml](.github/workflows/master-ci.yml): `CYPRESS_E2E_TEST_KEY: ${{ secrets.E2E_TEST_KEY }}` added to both `staging_e2e_test` and `prod_e2e_test` jobs.
- New `E2E_TEST_KEY` GitHub Actions secret already added by repo owner, matching the Cloudflare rule's secret value.

## Test plan
- [ ] Merge and let `staging_e2e_test` / `prod_e2e_test` run in CI
- [ ] Confirm Cypress e2e passes against prod (no more blocked `signin` request)
- [ ] Check Cloudflare Security Events shows no further hits on this rule for CI traffic

🤖 Generated with [Claude Code](https://claude.com/claude-code)