### PR TITLE
chore: add PR template following Conventional Commits

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,44 @@
+## Type
+
+<!-- Pick one, matching Conventional Commits (https://www.conventionalcommits.org/en/v1.0.0/) -->
+
+- [ ] feat: new feature
+- [ ] fix: bug fix
+- [ ] docs: documentation only
+- [ ] style: formatting, no code change
+- [ ] refactor: no feature/bug change
+- [ ] perf: performance improvement
+- [ ] test: adding/fixing tests
+- [ ] build: build system or dependencies
+- [ ] ci: CI configuration
+- [ ] chore: other, no src/test change
+- [ ] revert: reverts a previous commit
+
+## JIRA Card
+
+<!-- Scope, e.g. PROJ-123. Link the card. -->
+
+[PROJ-123](https://your-domain.atlassian.net/browse/PROJ-123)
+
+## Summary
+
+<!-- One-line summary, conventional-commits style: type(SCOPE): description -->
+<!-- e.g. feat(PROJ-123): add player stats export -->
+
+## Changes
+
+-
+
+## Test Plan
+
+-
+
+## Screenshots
+
+<!-- if UI change, else delete -->
+
+## Checklist
+
+- [ ] PR title follows Conventional Commits: `type(JIRA-CARD): description`
+- [ ] Tests added/updated
+- [ ] Docs updated if needed


### PR DESCRIPTION
## Summary
- Adds `.github/PULL_REQUEST_TEMPLATE.md` following [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/), using the JIRA card key as the optional scope (e.g. `feat(PROJ-123): ...`).

## Test plan
- N/A, template file only.